### PR TITLE
Use Guzzle Url to avoid trusted host verification issues w/ Symfony Request

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,8 +4,7 @@
     "license": "MIT",
     "require": {
         "php": ">=5.3.0",
-        "guzzle/guzzle": "3.*",
-        "symfony/http-foundation": "~2"
+        "guzzle/guzzle": "3.*"
     },
     "require-dev": {
         "phpunit/phpunit": "*",


### PR DESCRIPTION
If trusted hosts are configured (e.g., by [Symfony/FrameworkBundle](http://symfony.com/blog/security-releases-symfony-2-0-24-2-1-12-2-2-5-and-2-3-3-released)), the Symfony `Request::getHost()` method will throw an "untrusted host" exception during HMAC-SHA1 request signing (assuming it's host isn't whitelisted).

Unfortunately, `Request::$trustedHosts` is set statically, which limits how the Request class can be used in this library, when the library is a dependency of a Symfony2 app configured with trusted hosts.

I replaced the Symfony's Request class usage with Guzzle's Url class and directly passed `$method`. 