### PR TITLE
Add buildUrl method to Server class

### DIFF
--- a/src/Client/Server/Bitbucket.php
+++ b/src/Client/Server/Bitbucket.php
@@ -53,7 +53,6 @@ class Bitbucket extends Server
 
         foreach ($data as $key => $value) {
             if (strpos($key, 'url') !== false) {
-
                 if (!in_array($key, $used)) {
                     $used[] = $key;
                 }

--- a/src/Client/Server/Server.php
+++ b/src/Client/Server/Server.php
@@ -103,9 +103,9 @@ abstract class Server
         $parameters = array('oauth_token' => $temporaryIdentifier);
 
         $url = $this->urlAuthorization();
-        $query_string = http_build_query($parameters);
+        $queryString = http_build_query($parameters);
 
-        return $this->buildUrl($url, $query_string);
+        return $this->buildUrl($url, $queryString);
     }
 
     /**
@@ -510,13 +510,13 @@ abstract class Server
      * exisiting '?' character in host
      *
      * @param  string $host
-     * @param  string $query_string
+     * @param  string $queryString
      *
      * @return string
      */
-    protected function buildUrl($host, $query_string)
+    protected function buildUrl($host, $queryString)
     {
-        return $host . (strpos($host, '?') !== false ? '&' : '?') . $query_string;
+        return $host . (strpos($host, '?') !== false ? '&' : '?') . $queryString;
     }
 
     /**

--- a/src/Client/Server/Server.php
+++ b/src/Client/Server/Server.php
@@ -516,7 +516,7 @@ abstract class Server
      */
     protected function buildUrl($host, $query_string)
     {
-        return $host . (strpos($host, '?') !== FALSE ? '&' : '?') . $query_string;
+        return $host . (strpos($host, '?') !== false ? '&' : '?') . $query_string;
     }
 
     /**

--- a/src/Client/Server/Server.php
+++ b/src/Client/Server/Server.php
@@ -507,7 +507,7 @@ abstract class Server
 
     /**
      * Build a url by combining hostname and query string after checking for
-     * exisiting '?' character in host
+     * exisiting '?' character in host.
      *
      * @param  string $host
      * @param  string $queryString

--- a/src/Client/Server/Server.php
+++ b/src/Client/Server/Server.php
@@ -102,7 +102,10 @@ abstract class Server
 
         $parameters = array('oauth_token' => $temporaryIdentifier);
 
-        return $this->urlAuthorization().'?'.http_build_query($parameters);
+        $url = $this->urlAuthorization();
+        $query_string = http_build_query($parameters);
+
+        return $this->buildUrl($url, $query_string);
     }
 
     /**
@@ -500,6 +503,20 @@ abstract class Server
         $pool = '0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ';
 
         return substr(str_shuffle(str_repeat($pool, 5)), 0, $length);
+    }
+
+    /**
+     * Build a url by combining hostname and query string after checking for
+     * exisiting '?' character in host
+     *
+     * @param  string $host
+     * @param  string $query_string
+     *
+     * @return string
+     */
+    protected function buildUrl($host, $query_string)
+    {
+        return $host . (strpos($host, '?') !== FALSE ? '&' : '?') . $query_string;
     }
 
     /**

--- a/src/Client/Server/Twitter.php
+++ b/src/Client/Server/Twitter.php
@@ -56,7 +56,6 @@ class Twitter extends Server
 
         foreach ($data as $key => $value) {
             if (strpos($key, 'url') !== false) {
-
                 if (!in_array($key, $used)) {
                     $used[] = $key;
                 }


### PR DESCRIPTION
I am currently working on a OAuth 1 Server to be used in conjunction with this library. The OAuth provider allows for custom meta data to be passed to the authorization url with query string parameters. 

The current behavior of this class is such that it blindly concatenates the `urlAuthorization()` and `http_build_query($parameters)` with a `?` character separator.

I am proposing a change that adds a `buildUrl` method to the Server class. This method will now be used in the `getAuthorizationUrl()` method to return the complete authorization url.

With this change in place new Server implementations can declare urls that include query string parameters that will not break when the base Server class appends the `oauth_token`.

````php
    /**
     * {@inheritDoc}
     */
    public function urlAuthorization()
    {
        return 'http://www.example.com/authorize?foo=bar';
    }
    //http://www.example.com/authorize?foo=bar&oauth_token=abcdefg
````

````php
    /**
     * {@inheritDoc}
     */
    public function urlAuthorization()
    {
        return 'http://www.example.com/authorize';
    }
    //http://www.example.com/authorize?oauth_token=abcdefg
````