### PR TITLE
correcting phpcs errors for extra lines

### DIFF
--- a/src/Client/Server/Bitbucket.php
+++ b/src/Client/Server/Bitbucket.php
@@ -53,7 +53,6 @@ class Bitbucket extends Server
 
         foreach ($data as $key => $value) {
             if (strpos($key, 'url') !== false) {
-
                 if (!in_array($key, $used)) {
                     $used[] = $key;
                 }

--- a/src/Client/Server/Twitter.php
+++ b/src/Client/Server/Twitter.php
@@ -56,7 +56,6 @@ class Twitter extends Server
 
         foreach ($data as $key => $value) {
             if (strpos($key, 'url') !== false) {
-
                 if (!in_array($key, $used)) {
                     $used[] = $key;
                 }


### PR DESCRIPTION
There were empty lines in the Twitter and Bitbucket server classes. This was causing conflicts with Code Sniffer. This PR addresses that.

This may be related to this issue https://github.com/thephpleague/oauth1-client/issues/5