### PR TITLE
Add Trello server

### DIFF
--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -1,0 +1,35 @@
+filter:
+    excluded_paths: [tests/*]
+checks:
+    php:
+        code_rating: true
+        remove_extra_empty_lines: true
+        remove_php_closing_tag: true
+        remove_trailing_whitespace: true
+        fix_use_statements:
+            remove_unused: true
+            preserve_multiple: false
+            preserve_blanklines: true
+            order_alphabetically: true
+        fix_php_opening_tag: true
+        fix_linefeed: true
+        fix_line_ending: true
+        fix_identation_4spaces: true
+        fix_doc_comments: true
+tools:
+    external_code_coverage:
+        timeout: 600
+        runs: 3
+    php_analyzer: true
+    php_code_coverage: false
+    php_code_sniffer:
+        config:
+            standard: PSR2
+        filter:
+            paths: ['src']
+    php_loc:
+        enabled: true
+        excluded_dirs: [vendor, tests]
+    php_cpd:
+        enabled: true
+        excluded_dirs: [vendor, tests]

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,10 @@ script:
   - phpcs --standard=psr2 src/
   - phpunit --coverage-text
 
+after_script:
+  - wget https://scrutinizer-ci.com/ocular.phar
+  - php ocular.phar code-coverage:upload --format=php-clover coverage.clover
+
 matrix:
   allow_failures:
     - php: hhvm

--- a/README.md
+++ b/README.md
@@ -1,14 +1,18 @@
 # OAuth 1.0 Client
 
-[![Build Status](https://travis-ci.org/thephpleague/oauth1-client.png?branch=master)](https://travis-ci.org/thephpleague/oauth1-client)
-[![Total Downloads](https://poser.pugx.org/league/oauth1-client/downloads.png)](https://packagist.org/packages/league/oauth1-client)
-[![Latest Stable Version](https://poser.pugx.org/league/oauth1-client/v/stable.png)](https://packagist.org/packages/league/oauth1-client)
+[![Latest Stable Version](https://img.shields.io/github/release/thephpleague/oauth1-client.svg?style=flat-square)](https://github.com/thephpleague/oauth1-client/releases)
+[![Software License](https://img.shields.io/badge/license-MIT-brightgreen.svg?style=flat-square)](LICENSE.md)
+[![Build Status](https://img.shields.io/travis/thephpleague/oauth1-client/master.svg?style=flat-square&1)](https://travis-ci.org/thephpleague/oauth1-client)
+[![Coverage Status](https://img.shields.io/scrutinizer/coverage/g/thephpleague/oauth1-client.svg?style=flat-square)](https://scrutinizer-ci.com/g/thephpleague/oauth1-client/code-structure)
+[![Quality Score](https://img.shields.io/scrutinizer/g/thephpleague/oauth1-client.svg?style=flat-square)](https://scrutinizer-ci.com/g/thephpleague/oauth1-client)
+[![Total Downloads](https://img.shields.io/packagist/dt/thephpleague/oauth1-client.svg?style=flat-square)](https://packagist.org/packages/thephpleague/oauth1-client)
 
 OAuth 1 Client is an OAuth [RFC 5849 standards-compliant](http://tools.ietf.org/html/rfc5849) library for authenticating against OAuth 1 servers.
 
 It has built in support for:
 
 - Bitbucket
+- Trello
 - Tumblr
 - Twitter
 
@@ -78,6 +82,21 @@ Via Composer
 
 
 ## Usage
+
+### Trello
+
+```php
+$server =  new \Stevenmaguire\OAuth2\Client\Server\Trello(array(
+    'identifier' => 'your-identifier',
+    'secret' => 'your-secret',
+    'callback_uri' => 'http://your-callback-uri/',
+    'name' => 'your-application-name', // optional, defaults to null
+    'expiration' => 'your-application-expiration', // optional ('never', '1day', '2days'), defaults to '1day'
+    'scope' => 'your-application-scope' // optional ('read', 'read,write'), defaults to 'read'
+));
+```
+
+### Twitter
 
 ```php
 $server = new League\OAuth1\Client\Server\Twitter(array(
@@ -192,6 +211,7 @@ Please see [CONTRIBUTING](https://github.com/thephpleague/oauth1-client/blob/mas
 ## Credits
 
 - [Ben Corlett](https://github.com/bencorlett)
+- [Steven Maguire](https://github.com/stevenmaguire)
 - [All Contributors](https://github.com/thephpleague/oauth1-client/contributors)
 
 

--- a/README.md
+++ b/README.md
@@ -83,6 +83,16 @@ Via Composer
 
 ## Usage
 
+### Bitbucket
+
+```php
+$server = new League\OAuth1\Client\Server\Bitbucket(array(
+    'identifier' => 'your-identifier',
+    'secret' => 'your-secret',
+    'callback_uri' => "http://your-callback-uri/",
+));
+```
+
 ### Trello
 
 ```php
@@ -93,6 +103,16 @@ $server =  new League\OAuth1\Client\Server\Trello(array(
     'name' => 'your-application-name', // optional, defaults to null
     'expiration' => 'your-application-expiration', // optional ('never', '1day', '2days'), defaults to '1day'
     'scope' => 'your-application-scope' // optional ('read', 'read,write'), defaults to 'read'
+));
+```
+
+### Tumblr
+
+```php
+$server = new League\OAuth1\Client\Server\Tumblr(array(
+    'identifier' => 'your-identifier',
+    'secret' => 'your-secret',
+    'callback_uri' => "http://your-callback-uri/",
 ));
 ```
 

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ Via Composer
 ### Trello
 
 ```php
-$server =  new \Stevenmaguire\OAuth2\Client\Server\Trello(array(
+$server =  new League\OAuth1\Client\Server\Trello(array(
     'identifier' => 'your-identifier',
     'secret' => 'your-secret',
     'callback_uri' => 'http://your-callback-uri/',

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,11 @@
         "idp",
         "identity",
         "sso",
-        "single sign on"
+        "single sign on",
+        "bitbucket",
+        "trello",
+        "tumblr",
+        "twitter"
     ],
     "authors": [
         {

--- a/src/Client/Server/Trello.php
+++ b/src/Client/Server/Trello.php
@@ -53,7 +53,7 @@ class Trello extends Server
     }
 
     /**
-     * Set the access token
+     * Set the access token.
      *
      * @param string $accessToken
      *
@@ -66,7 +66,7 @@ class Trello extends Server
     }
 
     /**
-     * Set the application expiration
+     * Set the application expiration.
      *
      * @param string $applicationExpiration
      *
@@ -79,7 +79,7 @@ class Trello extends Server
     }
 
     /**
-     * Get application expiration
+     * Get application expiration.
      *
      * @return string
      */
@@ -89,7 +89,7 @@ class Trello extends Server
     }
 
     /**
-     * Set the application name
+     * Set the application name.
      *
      * @param string $applicationName
      *
@@ -102,7 +102,7 @@ class Trello extends Server
     }
 
     /**
-     * Get application name
+     * Get application name.
      *
      * @return string|null
      */
@@ -112,7 +112,7 @@ class Trello extends Server
     }
 
     /**
-     * Set the application scope
+     * Set the application scope.
      *
      * @param string $applicationScope
      *
@@ -125,7 +125,7 @@ class Trello extends Server
     }
 
     /**
-     * Get application scope
+     * Get application scope.
      *
      * @return string
      */
@@ -208,7 +208,7 @@ class Trello extends Server
     }
 
     /**
-     * Build authorization query parameters
+     * Build authorization query parameters.
      *
      * @return string
      */
@@ -225,7 +225,7 @@ class Trello extends Server
     }
 
     /**
-     * Parse configuration array to set attributes
+     * Parse configuration array to set attributes.
      *
      * @param  array $configuration
      */

--- a/src/Client/Server/Trello.php
+++ b/src/Client/Server/Trello.php
@@ -214,12 +214,12 @@ class Trello extends Server
      */
     private function buildAuthorizationQueryParameters()
     {
-        $params = [
+        $params = array(
             'response_type' => 'fragment',
             'scope' => $this->getApplicationScope(),
             'expiration' => $this->getApplicationExpiration(),
             'name' => $this->getApplicationName()
-        ];
+        );
 
         return http_build_query($params);
     }
@@ -231,12 +231,12 @@ class Trello extends Server
      */
     private function parseConfigurationArray(array $configuration = array())
     {
-        $config_attribute_map = [
+        $config_attribute_map = array(
             'identifier' => 'applicationKey',
             'expiration' => 'applicationExpiration',
             'name' => 'applicationName',
             'scope' => 'applicationScope'
-        ];
+        );
 
         foreach ($config_attribute_map as $config => $attr) {
             if (isset($configuration[$config])) {

--- a/src/Client/Server/Trello.php
+++ b/src/Client/Server/Trello.php
@@ -1,0 +1,247 @@
+<?php
+
+namespace League\OAuth1\Client\Server;
+
+use League\OAuth1\Client\Credentials\TokenCredentials;
+
+class Trello extends Server
+{
+    /**
+     * Access token
+     *
+     * @var string
+     */
+    protected $accessToken;
+
+    /**
+     * Application expiration
+     *
+     * @var string
+     */
+    protected $applicationExpiration;
+
+    /**
+     * Application key
+     *
+     * @var string
+     */
+    protected $applicationKey;
+
+    /**
+     * Application name
+     *
+     * @var string
+     */
+    protected $applicationName;
+
+    /**
+     * Application scope
+     *
+     * @var string
+     */
+    protected $applicationScope;
+
+    /**
+     * {@inheritDoc}
+     */
+    public function __construct($clientCredentials, SignatureInterface $signature = null)
+    {
+        parent::__construct($clientCredentials, $signature);
+        if (is_array($clientCredentials)) {
+            $this->parseConfigurationArray($clientCredentials);
+        }
+    }
+
+    /**
+     * Set the access token
+     *
+     * @param string $accessToken
+     *
+     * @return Trello
+     */
+    public function setAccessToken($accessToken)
+    {
+        $this->accessToken = $accessToken;
+        return $this;
+    }
+
+    /**
+     * Set the application expiration
+     *
+     * @param string $applicationExpiration
+     *
+     * @return Trello
+     */
+    public function setApplicationExpiration($applicationExpiration)
+    {
+        $this->applicationExpiration = $applicationExpiration;
+        return $this;
+    }
+
+    /**
+     * Get application expiration
+     *
+     * @return string
+     */
+    public function getApplicationExpiration()
+    {
+        return $this->applicationExpiration ?: '1day';
+    }
+
+    /**
+     * Set the application name
+     *
+     * @param string $applicationName
+     *
+     * @return Trello
+     */
+    public function setApplicationName($applicationName)
+    {
+        $this->applicationName = $applicationName;
+        return $this;
+    }
+
+    /**
+     * Get application name
+     *
+     * @return string|null
+     */
+    public function getApplicationName()
+    {
+        return $this->applicationName ?: null;
+    }
+
+    /**
+     * Set the application scope
+     *
+     * @param string $applicationScope
+     *
+     * @return Trello
+     */
+    public function setApplicationScope($applicationScope)
+    {
+        $this->applicationScope = $applicationScope;
+        return $this;
+    }
+
+    /**
+     * Get application scope
+     *
+     * @return string
+     */
+    public function getApplicationScope()
+    {
+        return $this->applicationScope ?: 'read';
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function urlTemporaryCredentials()
+    {
+        return 'https://trello.com/1/OAuthGetRequestToken';
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function urlAuthorization()
+    {
+        return 'https://trello.com/1/OAuthAuthorizeToken?'.
+            $this->buildAuthorizationQueryParameters();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function urlTokenCredentials()
+    {
+        return 'https://trello.com/1/OAuthGetAccessToken';
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function urlUserDetails()
+    {
+        return 'https://trello.com/1/members/me?key='.$this->applicationKey.'&token='.$this->accessToken;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function userDetails($data, TokenCredentials $tokenCredentials)
+    {
+        $user = new User;
+
+        $user->nickname = $data['username'];
+        $user->name = $data['fullName'];
+        $user->imageUrl = null;
+
+        $user->extra = (array) $data;
+
+        return $user;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function userUid($data, TokenCredentials $tokenCredentials)
+    {
+        return $data['id'];
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function userEmail($data, TokenCredentials $tokenCredentials)
+    {
+        return;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function userScreenName($data, TokenCredentials $tokenCredentials)
+    {
+        return $data['username'];
+    }
+
+    /**
+     * Build authorization query parameters
+     *
+     * @return string
+     */
+    private function buildAuthorizationQueryParameters()
+    {
+        $params = [
+            'response_type' => 'fragment',
+            'scope' => $this->getApplicationScope(),
+            'expiration' => $this->getApplicationExpiration(),
+            'name' => $this->getApplicationName()
+        ];
+
+        return http_build_query($params);
+    }
+
+    /**
+     * Parse configuration array to set attributes
+     *
+     * @param  array $configuration
+     */
+    private function parseConfigurationArray(array $configuration = array())
+    {
+        $config_attribute_map = [
+            'identifier' => 'applicationKey',
+            'expiration' => 'applicationExpiration',
+            'name' => 'applicationName',
+            'scope' => 'applicationScope'
+        ];
+
+        foreach ($config_attribute_map as $config => $attr) {
+            if (isset($configuration[$config])) {
+                $this->$attr = $configuration[$config];
+            }
+        }
+    }
+}

--- a/tests/TrelloServerTest.php
+++ b/tests/TrelloServerTest.php
@@ -42,7 +42,7 @@ class TrelloTest extends PHPUnit_Framework_TestCase
 
     public function testGettingTemporaryCredentials()
     {
-        $server = m::mock('Stevenmaguire\OAuth1\Client\Server\Trello[createHttpClient]');
+        $server = m::mock('League\OAuth1\Client\Server\Trello[createHttpClient]');
         $server->__construct($this->getMockClientCredentials());
 
         $server->shouldReceive('createHttpClient')->andReturn($client = m::mock('stdClass'));
@@ -192,7 +192,7 @@ class TrelloTest extends PHPUnit_Framework_TestCase
 
     public function testGettingTokenCredentials()
     {
-        $server = m::mock('Stevenmaguire\OAuth1\Client\Server\Trello[createHttpClient]');
+        $server = m::mock('League\OAuth1\Client\Server\Trello[createHttpClient]');
         $server->__construct($this->getMockClientCredentials());
 
         $temporaryCredentials = m::mock('League\OAuth1\Client\Credentials\TemporaryCredentials');
@@ -227,7 +227,7 @@ class TrelloTest extends PHPUnit_Framework_TestCase
 
     public function testGettingUserDetails()
     {
-        $server = m::mock('Stevenmaguire\OAuth1\Client\Server\Trello[createHttpClient,protocolHeader]');
+        $server = m::mock('League\OAuth1\Client\Server\Trello[createHttpClient,protocolHeader]');
         $server->__construct($this->getMockClientCredentials());
 
         $temporaryCredentials = m::mock('League\OAuth1\Client\Credentials\TokenCredentials');

--- a/tests/TrelloServerTest.php
+++ b/tests/TrelloServerTest.php
@@ -1,0 +1,350 @@
+<?php namespace League\OAuth1\Client\Tests;
+
+use League\OAuth1\Client\Server\Trello;
+use League\OAuth1\Client\Credentials\ClientCredentials;
+use Mockery as m;
+use PHPUnit_Framework_TestCase;
+
+class TrelloTest extends PHPUnit_Framework_TestCase
+{
+    /**
+     * Close mockery.
+     *
+     * @return void
+     */
+    public function tearDown()
+    {
+        m::close();
+    }
+
+    public function testCreatingWithArray()
+    {
+        $server = new Trello($this->getMockClientCredentials());
+
+        $credentials = $server->getClientCredentials();
+        $this->assertInstanceOf('League\OAuth1\Client\Credentials\ClientCredentialsInterface', $credentials);
+        $this->assertEquals($this->getApplicationKey(), $credentials->getIdentifier());
+        $this->assertEquals('mysecret', $credentials->getSecret());
+        $this->assertEquals('http://app.dev/', $credentials->getCallbackUri());
+    }
+
+    public function testCreatingWithObject()
+    {
+        $credentials = new ClientCredentials;
+        $credentials->setIdentifier('myidentifier');
+        $credentials->setSecret('mysecret');
+        $credentials->setCallbackUri('http://app.dev/');
+
+        $server = new Trello($credentials);
+
+        $this->assertEquals($credentials, $server->getClientCredentials());
+    }
+
+    public function testGettingTemporaryCredentials()
+    {
+        $server = m::mock('Stevenmaguire\OAuth1\Client\Server\Trello[createHttpClient]');
+        $server->__construct($this->getMockClientCredentials());
+
+        $server->shouldReceive('createHttpClient')->andReturn($client = m::mock('stdClass'));
+
+        $me = $this;
+        $client->shouldReceive('post')->with('https://trello.com/1/OAuthGetRequestToken', m::on(function($headers) use ($me) {
+            $me->assertTrue(isset($headers['Authorization']));
+
+            // OAuth protocol specifies a strict number of
+            // headers should be sent, in the correct order.
+            // We'll validate that here.
+            $pattern = '/OAuth oauth_consumer_key=".*?", oauth_nonce="[a-zA-Z0-9]+", oauth_signature_method="HMAC-SHA1", oauth_timestamp="\d{10}", oauth_version="1.0", oauth_callback="'.preg_quote('http%3A%2F%2Fapp.dev%2F', '/').'", oauth_signature=".*?"/';
+
+            $matches = preg_match($pattern, $headers['Authorization']);
+            $me->assertEquals(1, $matches, 'Asserting that the authorization header contains the correct expression.');
+
+            return true;
+        }))->once()->andReturn($request = m::mock('stdClass'));
+
+        $request->shouldReceive('send')->once()->andReturn($response = m::mock('stdClass'));
+        $response->shouldReceive('getBody')->andReturn('oauth_token=temporarycredentialsidentifier&oauth_token_secret=temporarycredentialssecret&oauth_callback_confirmed=true');
+
+        $credentials = $server->getTemporaryCredentials();
+        $this->assertInstanceOf('League\OAuth1\Client\Credentials\TemporaryCredentials', $credentials);
+        $this->assertEquals('temporarycredentialsidentifier', $credentials->getIdentifier());
+        $this->assertEquals('temporarycredentialssecret', $credentials->getSecret());
+    }
+
+    public function testGettingDefaultAuthorizationUrl()
+    {
+        $server = new Trello($this->getMockClientCredentials());
+
+        $expected = 'https://trello.com/1/OAuthAuthorizeToken?response_type=fragment&scope=read&expiration=1day&oauth_token=foo';
+
+        $this->assertEquals($expected, $server->getAuthorizationUrl('foo'));
+
+        $credentials = m::mock('League\OAuth1\Client\Credentials\TemporaryCredentials');
+        $credentials->shouldReceive('getIdentifier')->andReturn('foo');
+        $this->assertEquals($expected, $server->getAuthorizationUrl($credentials));
+    }
+
+    public function testGettingAuthorizationUrlWithExpirationAfterConstructingWithExpiration()
+    {
+        $credentials = $this->getMockClientCredentials();
+        $expiration = $this->getApplicationExpiration(2);
+        $credentials['expiration'] = $expiration;
+        $server = new Trello($credentials);
+
+        $expected = 'https://trello.com/1/OAuthAuthorizeToken?response_type=fragment&scope=read&expiration='.urlencode($expiration).'&oauth_token=foo';
+
+        $this->assertEquals($expected, $server->getAuthorizationUrl('foo'));
+
+        $credentials = m::mock('League\OAuth1\Client\Credentials\TemporaryCredentials');
+        $credentials->shouldReceive('getIdentifier')->andReturn('foo');
+        $this->assertEquals($expected, $server->getAuthorizationUrl($credentials));
+    }
+
+    public function testGettingAuthorizationUrlWithExpirationAfterSettingExpiration()
+    {
+        $expiration = $this->getApplicationExpiration(2);
+        $server = new Trello($this->getMockClientCredentials());
+        $server->setApplicationExpiration($expiration);
+
+        $expected = 'https://trello.com/1/OAuthAuthorizeToken?response_type=fragment&scope=read&expiration='.urlencode($expiration).'&oauth_token=foo';
+
+        $this->assertEquals($expected, $server->getAuthorizationUrl('foo'));
+
+        $credentials = m::mock('League\OAuth1\Client\Credentials\TemporaryCredentials');
+        $credentials->shouldReceive('getIdentifier')->andReturn('foo');
+        $this->assertEquals($expected, $server->getAuthorizationUrl($credentials));
+    }
+
+    public function testGettingAuthorizationUrlWithNameAfterConstructingWithName()
+    {
+        $credentials = $this->getMockClientCredentials();
+        $name = $this->getApplicationName();
+        $credentials['name'] = $name;
+        $server = new Trello($credentials);
+
+        $expected = 'https://trello.com/1/OAuthAuthorizeToken?response_type=fragment&scope=read&expiration=1day&name='.urlencode($name).'&oauth_token=foo';
+
+        $this->assertEquals($expected, $server->getAuthorizationUrl('foo'));
+
+        $credentials = m::mock('League\OAuth1\Client\Credentials\TemporaryCredentials');
+        $credentials->shouldReceive('getIdentifier')->andReturn('foo');
+        $this->assertEquals($expected, $server->getAuthorizationUrl($credentials));
+    }
+
+    public function testGettingAuthorizationUrlWithNameAfterSettingName()
+    {
+        $name = $this->getApplicationName();
+        $server = new Trello($this->getMockClientCredentials());
+        $server->setApplicationName($name);
+
+        $expected = 'https://trello.com/1/OAuthAuthorizeToken?response_type=fragment&scope=read&expiration=1day&name='.urlencode($name).'&oauth_token=foo';
+
+        $this->assertEquals($expected, $server->getAuthorizationUrl('foo'));
+
+        $credentials = m::mock('League\OAuth1\Client\Credentials\TemporaryCredentials');
+        $credentials->shouldReceive('getIdentifier')->andReturn('foo');
+        $this->assertEquals($expected, $server->getAuthorizationUrl($credentials));
+    }
+
+    public function testGettingAuthorizationUrlWithScopeAfterConstructingWithScope()
+    {
+        $credentials = $this->getMockClientCredentials();
+        $scope = $this->getApplicationScope(false);
+        $credentials['scope'] = $scope;
+        $server = new Trello($credentials);
+
+        $expected = 'https://trello.com/1/OAuthAuthorizeToken?response_type=fragment&scope='.urlencode($scope).'&expiration=1day&oauth_token=foo';
+
+        $this->assertEquals($expected, $server->getAuthorizationUrl('foo'));
+
+        $credentials = m::mock('League\OAuth1\Client\Credentials\TemporaryCredentials');
+        $credentials->shouldReceive('getIdentifier')->andReturn('foo');
+        $this->assertEquals($expected, $server->getAuthorizationUrl($credentials));
+    }
+
+    public function testGettingAuthorizationUrlWithScopeAfterSettingScope()
+    {
+        $scope = $this->getApplicationScope(false);
+        $server = new Trello($this->getMockClientCredentials());
+        $server->setApplicationScope($scope);
+
+        $expected = 'https://trello.com/1/OAuthAuthorizeToken?response_type=fragment&scope='.urlencode($scope).'&expiration=1day&oauth_token=foo';
+
+        $this->assertEquals($expected, $server->getAuthorizationUrl('foo'));
+
+        $credentials = m::mock('League\OAuth1\Client\Credentials\TemporaryCredentials');
+        $credentials->shouldReceive('getIdentifier')->andReturn('foo');
+        $this->assertEquals($expected, $server->getAuthorizationUrl($credentials));
+    }
+
+    /**
+     * @expectedException InvalidArgumentException
+     */
+    public function testGettingTokenCredentialsFailsWithManInTheMiddle()
+    {
+        $server = new Trello($this->getMockClientCredentials());
+
+        $credentials = m::mock('League\OAuth1\Client\Credentials\TemporaryCredentials');
+        $credentials->shouldReceive('getIdentifier')->andReturn('foo');
+
+        $server->getTokenCredentials($credentials, 'bar', 'verifier');
+    }
+
+    public function testGettingTokenCredentials()
+    {
+        $server = m::mock('Stevenmaguire\OAuth1\Client\Server\Trello[createHttpClient]');
+        $server->__construct($this->getMockClientCredentials());
+
+        $temporaryCredentials = m::mock('League\OAuth1\Client\Credentials\TemporaryCredentials');
+        $temporaryCredentials->shouldReceive('getIdentifier')->andReturn('temporarycredentialsidentifier');
+        $temporaryCredentials->shouldReceive('getSecret')->andReturn('temporarycredentialssecret');
+
+        $server->shouldReceive('createHttpClient')->andReturn($client = m::mock('stdClass'));
+
+        $me = $this;
+        $client->shouldReceive('post')->with('https://trello.com/1/OAuthGetAccessToken', m::on(function($headers) use ($me) {
+            $me->assertTrue(isset($headers['Authorization']));
+
+            // OAuth protocol specifies a strict number of
+            // headers should be sent, in the correct order.
+            // We'll validate that here.
+            $pattern = '/OAuth oauth_consumer_key=".*?", oauth_nonce="[a-zA-Z0-9]+", oauth_signature_method="HMAC-SHA1", oauth_timestamp="\d{10}", oauth_version="1.0", oauth_token="temporarycredentialsidentifier", oauth_signature=".*?"/';
+
+            $matches = preg_match($pattern, $headers['Authorization']);
+            $me->assertEquals(1, $matches, 'Asserting that the authorization header contains the correct expression.');
+
+            return true;
+        }), array('oauth_verifier' => 'myverifiercode'))->once()->andReturn($request = m::mock('stdClass'));
+
+        $request->shouldReceive('send')->once()->andReturn($response = m::mock('stdClass'));
+        $response->shouldReceive('getBody')->andReturn('oauth_token=tokencredentialsidentifier&oauth_token_secret=tokencredentialssecret');
+
+        $credentials = $server->getTokenCredentials($temporaryCredentials, 'temporarycredentialsidentifier', 'myverifiercode');
+        $this->assertInstanceOf('League\OAuth1\Client\Credentials\TokenCredentials', $credentials);
+        $this->assertEquals('tokencredentialsidentifier', $credentials->getIdentifier());
+        $this->assertEquals('tokencredentialssecret', $credentials->getSecret());
+    }
+
+    public function testGettingUserDetails()
+    {
+        $server = m::mock('Stevenmaguire\OAuth1\Client\Server\Trello[createHttpClient,protocolHeader]');
+        $server->__construct($this->getMockClientCredentials());
+
+        $temporaryCredentials = m::mock('League\OAuth1\Client\Credentials\TokenCredentials');
+        $temporaryCredentials->shouldReceive('getIdentifier')->andReturn('tokencredentialsidentifier');
+        $temporaryCredentials->shouldReceive('getSecret')->andReturn('tokencredentialssecret');
+
+        $server->shouldReceive('createHttpClient')->andReturn($client = m::mock('stdClass'));
+
+        $me = $this;
+        $client->shouldReceive('get')->with('https://trello.com/1/members/me?key='.$this->getApplicationKey().'&token='.$this->getAccessToken(), m::on(function($headers) use ($me) {
+            $me->assertTrue(isset($headers['Authorization']));
+
+            // OAuth protocol specifies a strict number of
+            // headers should be sent, in the correct order.
+            // We'll validate that here.
+            $pattern = '/OAuth oauth_consumer_key=".*?", oauth_nonce="[a-zA-Z0-9]+", oauth_signature_method="HMAC-SHA1", oauth_timestamp="\d{10}", oauth_version="1.0", oauth_token="tokencredentialsidentifier", oauth_signature=".*?"/';
+
+            $matches = preg_match($pattern, $headers['Authorization']);
+            $me->assertEquals(1, $matches, 'Asserting that the authorization header contains the correct expression.');
+
+            return true;
+        }))->once()->andReturn($request = m::mock('stdClass'));
+
+        $request->shouldReceive('send')->once()->andReturn($response = m::mock('stdClass'));
+        $response->shouldReceive('json')->once()->andReturn($this->getUserPayload());
+
+        $user = $server
+            ->setAccessToken($this->getAccessToken())
+            ->getUserDetails($temporaryCredentials);
+        $this->assertInstanceOf('League\OAuth1\Client\Server\User', $user);
+        $this->assertEquals('Matilda Wormwood', $user->name);
+        $this->assertEquals('545df696e29c0dddaed31967', $server->getUserUid($temporaryCredentials));
+        $this->assertEquals(null, $server->getUserEmail($temporaryCredentials));
+        $this->assertEquals('matildawormwood12', $server->getUserScreenName($temporaryCredentials));
+    }
+
+    protected function getMockClientCredentials()
+    {
+        return array(
+            'identifier' => $this->getApplicationKey(),
+            'secret' => 'mysecret',
+            'callback_uri' => 'http://app.dev/',
+        );
+    }
+
+    protected function getAccessToken()
+    {
+        return 'lmnopqrstuvwxyz';
+    }
+
+    protected function getApplicationKey()
+    {
+        return 'abcdefghijk';
+    }
+
+    protected function getApplicationExpiration($days = 0)
+    {
+        return is_numeric($days) && $days > 0 ? $days.'day'.($days == 1 ? '' : 's') : 'never';
+    }
+
+    protected function getApplicationName()
+    {
+        return 'fizz buzz';
+    }
+
+    protected function getApplicationScope($readonly = true)
+    {
+        return $readonly ? 'read' : 'read,write';
+    }
+
+    private function getUserPayload()
+    {
+        $user = '{
+            "id": "545df696e29c0dddaed31967",
+            "avatarHash": null,
+            "bio": "I have magical powers",
+            "bioData": null,
+            "confirmed": true,
+            "fullName": "Matilda Wormwood",
+            "idPremOrgsAdmin": [],
+            "initials": "MW",
+            "memberType": "normal",
+            "products": [],
+            "status": "idle",
+            "url": "https://trello.com/matildawormwood12",
+            "username": "matildawormwood12",
+            "avatarSource": "none",
+            "email": null,
+            "gravatarHash": "39aaaada0224f26f0bb8f1965326dcb7",
+            "idBoards": [
+                "545df696e29c0dddaed31968",
+                "545e01d6c7b2dd962b5b46cb"
+            ],
+            "idOrganizations": [
+                "54adfd79f9aea14f84009a85",
+                "54adfde13b0e706947bc4789"
+            ],
+            "loginTypes": null,
+            "oneTimeMessagesDismissed": [],
+            "prefs": {
+                "sendSummaries": true,
+                "minutesBetweenSummaries": 1,
+                "minutesBeforeDeadlineToNotify": 1440,
+                "colorBlind": false,
+                "timezoneInfo": {
+                    "timezoneNext": "CDT",
+                    "dateNext": "2015-03-08T08:00:00.000Z",
+                    "offsetNext": 300,
+                    "timezoneCurrent": "CST",
+                    "offsetCurrent": 360
+                }
+            },
+            "trophies": [],
+            "uploadedAvatarHash": null,
+            "premiumFeatures": [],
+            "idBoardsPinned": null
+        }';
+        return json_decode($user, true);
+    }
+}


### PR DESCRIPTION
This request proposes the addition of a Trello OAuth 1 Client Server. This code migrating from https://github.com/stevenmaguire/trello-oauth1-server

I have introduced the new Trello Server class, and a separate supporting test class to cover additional functionality offered by the vendor specific class that is above and beyond the parent Server class. I have also added specific documentation to the Readme for the Trello usage.

I have introduced a Scrutinizer config file, as well as the supporting changes to the Travis config file to provide more visibility in the quality of the code. 