### PR TITLE
adding support for setting user agent

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+/build
 /vendor
 /composer.lock
 .DS_Store

--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,8 @@
     },
     "require-dev": {
         "phpunit/phpunit": "*",
-        "mockery/mockery": "0.7.2"
+        "mockery/mockery": "0.7.2",
+        "satooshi/php-coveralls": "dev-master"
     },
     "keywords": [
         "oauth",

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -5,6 +5,16 @@
          convertErrorsToExceptions="true"
          convertNoticesToExceptions="true"
          convertWarningsToExceptions="true">
+    <logging>
+        <log type="coverage-html"
+                target="./build/coverage/html"
+                charset="UTF-8"
+                highlight="false"
+                lowUpperBound="35"
+                highLowerBound="70"/>
+          <log type="coverage-clover"
+                target="./build/coverage/log/coverage.xml"/>
+    </logging>
     <testsuites>
         <testsuite name="common">
             <directory suffix="Test.php">tests</directory>

--- a/src/Client/Server/Server.php
+++ b/src/Client/Server/Server.php
@@ -44,6 +44,13 @@ abstract class Server
     protected $cachedUserDetailsResponse;
 
     /**
+     * Optional user agent
+     *
+     * @var string
+     */
+    protected $userAgent;
+
+    /**
      * Create a new server instance.
      *
      * @param  ClientCredentialsInterface|array  $clientCredentials
@@ -74,10 +81,12 @@ abstract class Server
 
         $client = $this->createHttpClient();
 
+        $header = $this->temporaryCredentialsProtocolHeader($uri);
+        $authorization_header = array('Authorization' => $header);
+        $headers = $this->buildHttpClientHeaders($authorization_header);
+
         try {
-            $response = $client->post($uri, array(
-                'Authorization' => $this->temporaryCredentialsProtocolHeader($uri),
-            ))->send();
+            $response = $client->post($uri, $headers)->send();
         } catch (BadResponseException $e) {
             return $this->handleTemporaryCredentialsBadResponse($e);
         }
@@ -147,11 +156,11 @@ abstract class Server
         $client = $this->createHttpClient();
 
         $header = $this->protocolHeader('POST', $uri, $temporaryCredentials, $bodyParameters);
+        $authorization_header = array('Authorization' => $header);
+        $headers = $this->buildHttpClientHeaders($authorization_header);
 
         try {
-            $response = $client->post($uri, array(
-                'Authorization' => $header,
-            ), $bodyParameters)->send();
+            $response = $client->post($uri, $headers, $bodyParameters)->send();
         } catch (BadResponseException $e) {
             return $this->handleTokenCredentialsBadResponse($e);
         }
@@ -222,10 +231,12 @@ abstract class Server
 
             $client = $this->createHttpClient();
 
+            $header = $this->protocolHeader('GET', $url, $tokenCredentials);
+            $authorization_header = array('Authorization' => $header);
+            $headers = $this->buildHttpClientHeaders($authorization_header);
+
             try {
-                $response = $client->get($url, array(
-                    'Authorization' => $this->protocolHeader('GET', $url, $tokenCredentials),
-                ))->send();
+                $response = $client->get($url, $headers)->send();
             } catch (BadResponseException $e) {
                 $response = $e->getResponse();
                 $body = $response->getBody();
@@ -285,6 +296,44 @@ abstract class Server
     public function createHttpClient()
     {
         return new GuzzleClient();
+    }
+
+    /**
+     * Set the user agent value.
+     *
+     * @param  string $userAgent
+     *
+     * @return Server
+     */
+    public function setUserAgent($userAgent = null)
+    {
+        $this->userAgent = $userAgent;
+        return $this;
+    }
+
+    /**
+     * Get Guzzle HTTP client default headers.
+     *
+     * @return array
+     */
+    protected function getHttpClientDefaultHeaders()
+    {
+        $default_headers = array();
+        if (!empty($this->userAgent)) {
+            $default_headers['User-Agent'] = $this->userAgent;
+        }
+        return $default_headers;
+    }
+
+    /**
+     * Build Guzzle HTTP client headers.
+     *
+     * @return array
+     */
+    protected function buildHttpClientHeaders($headers = array())
+    {
+        $default_headers = $this->getHttpClientDefaultHeaders();
+        return array_merge($headers, $default_headers);
     }
 
     /**

--- a/src/Client/Server/Server.php
+++ b/src/Client/Server/Server.php
@@ -82,8 +82,8 @@ abstract class Server
         $client = $this->createHttpClient();
 
         $header = $this->temporaryCredentialsProtocolHeader($uri);
-        $authorization_header = array('Authorization' => $header);
-        $headers = $this->buildHttpClientHeaders($authorization_header);
+        $authorizationHeader = array('Authorization' => $header);
+        $headers = $this->buildHttpClientHeaders($authorizationHeader);
 
         try {
             $response = $client->post($uri, $headers)->send();
@@ -156,8 +156,8 @@ abstract class Server
         $client = $this->createHttpClient();
 
         $header = $this->protocolHeader('POST', $uri, $temporaryCredentials, $bodyParameters);
-        $authorization_header = array('Authorization' => $header);
-        $headers = $this->buildHttpClientHeaders($authorization_header);
+        $authorizationHeader = array('Authorization' => $header);
+        $headers = $this->buildHttpClientHeaders($authorizationHeader);
 
         try {
             $response = $client->post($uri, $headers, $bodyParameters)->send();
@@ -232,8 +232,8 @@ abstract class Server
             $client = $this->createHttpClient();
 
             $header = $this->protocolHeader('GET', $url, $tokenCredentials);
-            $authorization_header = array('Authorization' => $header);
-            $headers = $this->buildHttpClientHeaders($authorization_header);
+            $authorizationHeader = array('Authorization' => $header);
+            $headers = $this->buildHttpClientHeaders($authorizationHeader);
 
             try {
                 $response = $client->get($url, $headers)->send();
@@ -318,11 +318,11 @@ abstract class Server
      */
     protected function getHttpClientDefaultHeaders()
     {
-        $default_headers = array();
+        $defaultHeaders = array();
         if (!empty($this->userAgent)) {
-            $default_headers['User-Agent'] = $this->userAgent;
+            $defaultHeaders['User-Agent'] = $this->userAgent;
         }
-        return $default_headers;
+        return $defaultHeaders;
     }
 
     /**
@@ -332,8 +332,8 @@ abstract class Server
      */
     protected function buildHttpClientHeaders($headers = array())
     {
-        $default_headers = $this->getHttpClientDefaultHeaders();
-        return array_merge($headers, $default_headers);
+        $defaultHeaders = $this->getHttpClientDefaultHeaders();
+        return array_merge($headers, $defaultHeaders);
     }
 
     /**


### PR DESCRIPTION
In response to https://github.com/thephpleague/oauth1-client/issues/8, this PR proposes a solution that includes a new `setUserAgent` method which sets a protected property on the base `Server` class, so all vendor specific implementations can utilize this feature. 

When building the `Authorization` header for each request, the custom header is passed into a `buildHttpClientHeaders` method, where it is merged with a default set of headers. This default set of headers is empty unless the `userAgent` is set, in which case it will include the header in the response.

This solution does not provide a method to unset the `userAgent` property, but the `setUserAgent` method accepts and sets null.

Additionally, the merge is configured in such a way that each of the requesting methods can set User-Agent independently and it will not be overwritten.

There is a new test that covers these new methods as well as an update to existing test to cover the case where the `userAgent` is not set, ensuring no `User-Agent` header is sent.

````php
$header = $this->protocolHeader('GET', $url, $tokenCredentials);
$authorization_header = array('Authorization' => $header);
$headers = $this->buildHttpClientHeaders($authorization_header);

try {
    $response = $client->get($url, $headers)->send();
} catch (BadResponseException $e) {
    $response = $e->getResponse();
    $body = $response->getBody();
    $statusCode = $response->getStatusCode();

    throw new \Exception(
        "Received error [$body] with status code [$statusCode] when retrieving token credentials."
    );
}
````