### PR TITLE
Add a Magento server client

### DIFF
--- a/src/Client/Server/Magento.php
+++ b/src/Client/Server/Magento.php
@@ -1,0 +1,157 @@
+<?php
+
+namespace League\OAuth1\Client\Server;
+
+use League\OAuth1\Client\Credentials\TemporaryCredentials;
+use League\OAuth1\Client\Credentials\TokenCredentials;
+
+/**
+ * Magento OAuth 1.0a
+ *
+ * This class reflects two Magento oddities:
+ *  - Magento does not offer a user info endpoint for the currently
+ *    authenticated user.
+ *  - Magento expects the oauth_verifier to be located in the header instead of
+ *    the post body.
+ *
+ * Additionally, this is initialized with two additional parameters:
+ *  - Boolean 'admin' to use the admin vs customer
+ *  - String 'host' with the path to the magento host
+ */
+class Magento extends Server
+{
+    /**
+     * oauth_verifier stored for use with
+     * @var string
+     */
+    private $verifier;
+
+    /**
+    * {@inheritDoc}
+    */
+    public function __construct($clientCredentials, SignatureInterface $signature = null)
+    {
+        parent::__construct($clientCredentials, $signature);
+        if (is_array($clientCredentials)) {
+            $this->parseConfigurationArray($clientCredentials);
+        }
+    }
+
+    /**
+    * {@inheritDoc}
+    */
+    public function urlTemporaryCredentials()
+    {
+        return $this->baseUri . '/oauth/initiate';
+    }
+
+    /**
+    * {@inheritDoc}
+    */
+    public function urlAuthorization()
+    {
+        return $this->isAdmin
+            ? $this->baseUri . '/admin/oauth_authorize'
+            : $this->baseUri . '/oauth/authorize';
+    }
+
+    /**
+    * {@inheritDoc}
+    */
+    public function urlTokenCredentials()
+    {
+        return $this->baseUri .'/oauth/token';
+    }
+
+
+    /**
+    * {@inheritDoc}
+    */
+    public function urlUserDetails()
+    {
+        return '';
+    }
+
+    /**
+    * {@inheritDoc}
+    */
+    public function userDetails($data, TokenCredentials $tokenCredentials)
+    {
+        return new User;
+    }
+
+    /**
+    * {@inheritDoc}
+    */
+    public function userUid($data, TokenCredentials $tokenCredentials)
+    {
+        return;
+    }
+
+    /**
+    * {@inheritDoc}
+    */
+    public function userEmail($data, TokenCredentials $tokenCredentials)
+    {
+        return;
+    }
+
+    /**
+    * {@inheritDoc}
+    */
+    public function userScreenName($data, TokenCredentials $tokenCredentials)
+    {
+        return;
+    }
+
+    /**
+    * {@inheritDoc}
+    */
+    public function getTokenCredentials(TemporaryCredentials $temporaryCredentials, $temporaryIdentifier, $verifier)
+    {
+        $this->verifier = $verifier;
+        return parent::getTokenCredentials($temporaryCredentials, $temporaryIdentifier, $verifier);
+    }
+
+    /**
+    * {@inheritDoc}
+    */
+    protected function additionalProtocolParameters()
+    {
+        return array(
+            'oauth_verifier' => $this->verifier
+        );
+    }
+
+    /**
+     * Magento does not implement a user info endpoint
+     *
+     * @param  TokenCredentials $tokenCredentials
+     * @param  bool $force
+     * @return array empty array
+     */
+    protected function fetchUserDetails(TokenCredentials $tokenCredentials, $force = true)
+    {
+        return array();
+    }
+
+    /**
+     * Parse configuration array to set attributes.
+     *
+     * @param  array $configuration
+     */
+    private function parseConfigurationArray(array $configuration = array())
+    {
+        if (isset($url['host'])) {
+            throw new \Exception('Missing Magento Host');
+        }
+
+        $url = parse_url($configuration['host']);
+        $this->baseUri = sprintf('%s://%s', $url['scheme'], $url['host']);
+        if (isset($url['path'])) {
+            $this->baseUri .= '/' . trim($url['path'], '/');
+        }
+
+        $this->isAdmin = !empty($configuration['admin']);
+    }
+}

--- a/src/Client/Server/Server.php
+++ b/src/Client/Server/Server.php
@@ -224,6 +224,13 @@ abstract class Server
         return $this->userScreenName($data, $tokenCredentials);
     }
 
+    /**
+     * Fetch user details from the remote service
+     *
+     * @param  TokenCredentials  $tokenCredentials
+     * @param  bool  $force
+     * @return array HTTP client response
+     */
     protected function fetchUserDetails(TokenCredentials $tokenCredentials, $force = true)
     {
         if (!$this->cachedUserDetailsResponse || $force == true) {
@@ -509,9 +516,13 @@ abstract class Server
      */
     protected function protocolHeader($method, $uri, CredentialsInterface $credentials, array $bodyParameters = array())
     {
-        $parameters = array_merge($this->baseProtocolParameters(), array(
-            'oauth_token' => $credentials->getIdentifier(),
-        ));
+        $parameters = array_merge(
+            $this->baseProtocolParameters(),
+            $this->additionalProtocolParameters(),
+            array(
+                'oauth_token' => $credentials->getIdentifier(),
+            )
+        );
 
         $this->signature->setCredentials($credentials);
 


### PR DESCRIPTION
New Magento server client with support for regular and admin users.

Magento is unique in that it's not a single service like Twitter or Tumblr, but instead is a hosted instance. This requires us to construct with the base uri of the host. In addition, Magento has two separate authorization urls based on whether we are authenticating as an admin or a store user/customer.

This PR also has a small change to the `protocolHeader()` method to include the `additionalProtocolParameters()`.