### PR TITLE
Add Email for Twitter

### DIFF
--- a/src/Client/Server/Twitter.php
+++ b/src/Client/Server/Twitter.php
@@ -35,7 +35,7 @@ class Twitter extends Server
      */
     public function urlUserDetails()
     {
-        return 'https://api.twitter.com/1.1/account/verify_credentials.json';
+        return 'https://api.twitter.com/1.1/account/verify_credentials.json?include_email=true';
     }
 
     /**
@@ -51,8 +51,12 @@ class Twitter extends Server
         $user->location = $data['location'];
         $user->description = $data['description'];
         $user->imageUrl = $data['profile_image_url'];
+        $user->email = null;
+        if (isset($data['email'])) {
+            $user->email = $data['email'];
+        }
 
-        $used = array('id', 'screen_name', 'name', 'location', 'description', 'profile_image_url');
+        $used = array('id', 'screen_name', 'name', 'location', 'description', 'profile_image_url', 'email');
 
         foreach ($data as $key => $value) {
             if (strpos($key, 'url') !== false) {


### PR DESCRIPTION
Since April of this year (2015) Twitter is now able to supply a user's email address, with one caveat - you need to have your app whitelisted.

More information here: https://dev.twitter.com/rest/reference/get/account/verify_credentials