### PR TITLE
fix passing host, and hosts with different port for magento

### DIFF
--- a/src/Client/Server/Magento.php
+++ b/src/Client/Server/Magento.php
@@ -172,7 +172,7 @@ class Magento extends Server
         $url = parse_url($configuration['host']);
         $this->baseUri = sprintf('%s://%s', $url['scheme'], $url['host']);
 
-        if(isset($url['port'])) {
+        if (isset($url['port'])) {
             $this->baseUri .= ':'.$url['port'];
         }
 

--- a/src/Client/Server/Magento.php
+++ b/src/Client/Server/Magento.php
@@ -162,14 +162,20 @@ class Magento extends Server
      * Parse configuration array to set attributes.
      *
      * @param array $configuration
+     * @throws \Exception
      */
     private function parseConfigurationArray(array $configuration = array())
     {
-        if (isset($configuration['host'])) {
+        if (!isset($configuration['host'])) {
             throw new \Exception('Missing Magento Host');
         }
         $url = parse_url($configuration['host']);
         $this->baseUri = sprintf('%s://%s', $url['scheme'], $url['host']);
+
+        if(isset($url['port'])) {
+            $this->baseUri .= ':'.$url['port'];
+        }
+
         if (isset($url['path'])) {
             $this->baseUri .= '/'.trim($url['path'], '/');
         }


### PR DESCRIPTION
I tried to run this code to connect to a local magento installation:
```php
$magento = new \League\OAuth1\Client\Server\Magento(array(
    'host' => 'http://127.0.0.1:8080/',
    'identifier' => 'identifier',
    'secret' => 'secret',
    'callback_uri' => 'http://localhost',
    'admin' => true, // optional, default false
));
```

 * it resulted in an exception as it checked if the host was *not* set, although it is used later on
 * the alternative port was not passed to the base url