### PR TITLE
Change installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,12 +83,8 @@ so please help them out with a pull request if you notice this.
 
 Via Composer
 
-```json
-{
-    "require": {
-        "league/oauth1-client": "~1.0"
-    }
-}
+```shell
+$ composer require league/oauth1-client
 ```
 
 


### PR DESCRIPTION
Packages should be installed using the `composer require` command, not by editing the `composer.json` directly.

We don't want to wake the Dohmkraken!