### PR TITLE
Use id_str instead of id for Twitter IDs

### DIFF
--- a/src/Client/Server/Twitter.php
+++ b/src/Client/Server/Twitter.php
@@ -45,7 +45,7 @@ class Twitter extends Server
     {
         $user = new User();
 
-        $user->uid = $data['id'];
+        $user->uid = $data['id_str'];
         $user->nickname = $data['screen_name'];
         $user->name = $data['name'];
         $user->location = $data['location'];


### PR DESCRIPTION
Noticed the `id` field was being used for a user's Twitter ID. Twitter highly recommends using the `id_str` field instead due to issues with how large integers are handled in a lot of systems. It's _probably_ not actually an issue in practice in this case, but I've personally run into issues due to this when working with the Twitter API in a Javascript environment, and since it's recommended by their documentation, it seems like it's probably a better choice than using the integer field.

![image](https://cloud.githubusercontent.com/assets/4323180/11344694/c9445b10-91e0-11e5-8e1e-00fb38dec341.png)

https://dev.twitter.com/overview/api/twitter-ids-json-and-snowflake