### PR TITLE
Support query string and request parameters with arrays

### DIFF
--- a/src/Client/Signature/HmacSha1Signature.php
+++ b/src/Client/Signature/HmacSha1Signature.php
@@ -73,7 +73,7 @@ class HmacSha1Signature extends Signature implements SignatureInterface
         }
 
         // compare the keys, then compare the values if the keys are identical
-        usort($data, function($a, $b) {
+        usort($data, function ($a, $b) {
             return strcmp($a[0], $b[0]) ?: strcmp($a[1], $b[1]);
         });
 

--- a/src/Client/Signature/HmacSha1Signature.php
+++ b/src/Client/Signature/HmacSha1Signature.php
@@ -61,20 +61,30 @@ class HmacSha1Signature extends Signature implements SignatureInterface
         $baseString .= rawurlencode($schemeHostPath).'&';
 
         $data = array();
-        parse_str($url->getQuery(), $query);
+        $query = $this->parseQuery($url->getQuery());
         foreach (array_merge($query, $parameters) as $key => $value) {
-            $data[rawurlencode($key)] = rawurlencode($value);
+            if (is_array($value)) {
+                foreach ($value as $subValue) {
+                    $data[] = array(rawurlencode($key), rawurlencode($subValue));
+                }
+            } else {
+                $data[] = array(rawurlencode($key), rawurlencode($value));
+            }
         }
 
-        ksort($data);
-        array_walk($data, function (&$value, $key) {
-            $value = $key.'='.$value;
+        // compare the keys, then compare the values if the keys are identical
+        usort($data, function($a, $b) {
+            return strcmp($a[0], $b[0]) ?: strcmp($a[1], $b[1]);
         });
+
+        foreach ($data as $key => $pair) {
+            $data[$key] = sprintf('%s=%s', $pair[0], $pair[1]);
+        }
+
         $baseString .= rawurlencode(implode('&', $data));
 
         return $baseString;
     }
-
 
     /**
      * Parses a query string into components including properly parsing queries that have array in them like a[]=1

--- a/src/Client/Signature/HmacSha1Signature.php
+++ b/src/Client/Signature/HmacSha1Signature.php
@@ -75,6 +75,51 @@ class HmacSha1Signature extends Signature implements SignatureInterface
         return $baseString;
     }
 
+
+    /**
+     * Parses a query string into components including properly parsing queries that have array in them like a[]=1
+     * or a[hello]=1.
+     *
+     * @param string $query The query string to parse into an associative array.
+     *
+     * @return array The parsed query into a single-level associative array.
+     */
+    protected function parseQuery($query)
+    {
+        $parsed = array();
+        $parts = explode('&', $query);
+
+        foreach ($parts as $part) {
+            $equalsPos = strpos($part, '=');
+
+            if ($equalsPos === false) {
+                $key   = urldecode($part);
+                $value = '';
+            } else {
+                $key   = urldecode(substr($part, 0, $equalsPos));
+                $value = urldecode(substr($part, $equalsPos + 1));
+            }
+
+            //Example where the key for 'c' is '': a=b&=c
+            if ($key == '') {
+                continue;
+            }
+
+            if (!isset($parsed[$key])) {
+                $parsed[$key] = $value;
+            } else {
+                //ensure this is an array since we need to store multiple values
+                if (!is_array($parsed[$key])) {
+                    $parsed[$key] = array($parsed[$key]);
+                }
+
+                $parsed[$key][] = $value;
+            }
+        }
+
+        return $parsed;
+    }
+
     /**
      * Hashes a string with the signature's key.
      *

--- a/tests/HmacSha1SignatureTest.php
+++ b/tests/HmacSha1SignatureTest.php
@@ -22,6 +22,21 @@ use League\OAuth1\Client\Signature\HmacSha1Signature;
 use Mockery as m;
 use PHPUnit_Framework_TestCase;
 
+/**
+ * Class HmacSha1SignatureTest
+ *
+ * This class validates assertions about the HMAC SHA1 signatures. Note that wherever you see some base64 encoded
+ * signature that is used as an assertion, you can calculate the actual signature by using this method:
+ *
+ * base64_encode(hash_hmac('sha1', $base, 'clientsecret&', true));
+ *
+ * The 'clientsecret&' above is embedded in the mock object in this class.
+ *
+ * Note that for convenience, the expected pre-signed string is included in each test so that you can see what the
+ * expectation is prior to signing if you are making modifications to this test or the HMAC-SHA1 implementation.
+ *
+ * @package League\OAuth1\Client\Tests
+ */
 class HmacSha1SignatureTest extends PHPUnit_Framework_TestCase
 {
     /**
@@ -89,7 +104,6 @@ class HmacSha1SignatureTest extends PHPUnit_Framework_TestCase
         );
     }
 
-
     public function testAssociativeArraysAreParsed()
     {
         $query = 'a[hello]=1&a[hello]=2&b[hi][wut]=c&b[hi][yay]=d';
@@ -108,7 +122,21 @@ class HmacSha1SignatureTest extends PHPUnit_Framework_TestCase
         $uri = 'http://www.example.com/?qux=corge';
         $parameters = array('foo' => 'bar', 'baz' => null);
 
+        // Base string: POST&http%3A%2F%2Fwww.example.com%2F&baz%3D%26foo%3Dbar%26qux%3Dcorge
+
         $this->assertEquals('A3Y7C1SUHXR1EBYIUlT3d6QT1cQ=', $signature->sign($uri, $parameters));
+    }
+
+    public function testSigningRequestWithArrayParams()
+    {
+        $signature = new HmacSha1Signature($this->getMockClientCredentials());
+
+        $uri = 'http://www.example.com/?qux[][f]=corge&qux[][f]=egroc';
+        $parameters = array('foo' => 'bar', 'baz' => null);
+
+        // Base string: POST&http%3A%2F%2Fwww.example.com%2F&baz%3D%26foo%3Dbar%26qux%255B%255D%255Bf%255D%3Dcorge%26qux%255B%255D%255Bf%255D%3Degroc
+
+        $this->assertEquals('JXp+kndmPKBtHoLiXBt7CCJAplw=', $signature->sign($uri, $parameters));
     }
 
     protected function invokeParseQuery(array $args)


### PR DESCRIPTION
Implemented a fix to support queries or request parameters that contain associative arrays or indices. For example, if trying to sign a URL like `https://example.org/hello?what[]=1&what[]=2&is[][second]=hello&is[][second]=this` then the base string generation fails because an array is encountered. Furthermore, this implementation does *not* use the `parse_url` method because it does it incorrectly with respect to how we need to actually sign the end request.

Fixes #39 