### PR TITLE
[2.0] Update post request builder to use json_encoded string

### DIFF
--- a/src/Server/AbstractServer.php
+++ b/src/Server/AbstractServer.php
@@ -504,9 +504,10 @@ abstract class AbstractServer
         $uri = $this->getBaseTokenCredentialsUrl();
         $bodyParameters = array('oauth_verifier' => $verifier);
         $headers = $this->getHeaders($temporaryCredentials, 'POST', $uri, $bodyParameters);
+        $body = json_encode($bodyParameters);
 
         try {
-            $request = $this->getRequestFactory()->getRequest('POST', $uri, $headers, $bodyParameters);
+            $request = $this->getRequestFactory()->getRequest('POST', $uri, $headers, $body);
             $response = $this->getHttpClient()->send($request);
         } catch (BadResponseException $e) {
             CredentialsException::handleTokenCredentialsBadResponse($e);

--- a/test/src/Server/AbstractServerTest.php
+++ b/test/src/Server/AbstractServerTest.php
@@ -343,7 +343,7 @@ class AbstractServerTest extends PHPUnit_Framework_TestCase
         $requestFactory = m::mock(RequestFactoryInterface::class);
         $requestFactory->shouldReceive('getRequest')->with('POST', 'http://your.service/token-credentials', m::on(function ($headers) use ($headerPattern) {
             return $this->isTokenAuthenticatedRequest($headerPattern, $headers);
-        }), array('oauth_verifier' => 'myverifiercode'))->once()->andReturn($request);
+        }), json_encode(array('oauth_verifier' => 'myverifiercode')))->once()->andReturn($request);
 
         $httpClient = $this->getHttpClientMock($request, $payload);
 
@@ -370,7 +370,7 @@ class AbstractServerTest extends PHPUnit_Framework_TestCase
         $requestFactory = m::mock(RequestFactoryInterface::class);
         $requestFactory->shouldReceive('getRequest')->with('POST', 'http://your.service/token-credentials', m::on(function ($headers) {
             return is_array($headers);
-        }), array('oauth_verifier' => 'myverifiercode'))->once()->andReturn($request);
+        }), json_encode(array('oauth_verifier' => 'myverifiercode')))->once()->andReturn($request);
 
         $httpClient = $this->getHttpClientMock($request, null, 400);
 
@@ -395,7 +395,7 @@ class AbstractServerTest extends PHPUnit_Framework_TestCase
         $requestFactory = m::mock(RequestFactoryInterface::class);
         $requestFactory->shouldReceive('getRequest')->with('POST', 'http://your.service/token-credentials', m::on(function ($headers) use ($headerPattern) {
             return $this->isTokenAuthenticatedRequest($headerPattern, $headers);
-        }), array('oauth_verifier' => 'myverifiercode'))->once()->andReturn($request);
+        }), json_encode(array('oauth_verifier' => 'myverifiercode')))->once()->andReturn($request);
 
         $httpClient = $this->getHttpClientMock($request, $payload);
 
@@ -420,7 +420,7 @@ class AbstractServerTest extends PHPUnit_Framework_TestCase
         $requestFactory = m::mock(RequestFactoryInterface::class);
         $requestFactory->shouldReceive('getRequest')->with('POST', 'http://your.service/token-credentials', m::on(function ($headers) use ($headerPattern) {
             return $this->isTokenAuthenticatedRequest($headerPattern, $headers);
-        }), array('oauth_verifier' => 'myverifiercode'))->once()->andReturn($request);
+        }), json_encode(array('oauth_verifier' => 'myverifiercode')))->once()->andReturn($request);
 
         $httpClient = $this->getHttpClientMock($request, $payload);
 
@@ -443,7 +443,7 @@ class AbstractServerTest extends PHPUnit_Framework_TestCase
         $requestFactory = m::mock(RequestFactoryInterface::class);
         $requestFactory->shouldReceive('getRequest')->with('POST', 'http://your.service/token-credentials', m::on(function ($headers) use ($userAgent, $headerPattern) {
             return $this->isTokenAuthenticatedRequest($headerPattern, $headers, $userAgent);
-        }), array('oauth_verifier' => 'myverifiercode'))->once()->andReturn($request);
+        }), json_encode(array('oauth_verifier' => 'myverifiercode')))->once()->andReturn($request);
 
         $httpClient = $this->getHttpClientMock($request, $payload);
 


### PR DESCRIPTION
Previously, the package was sending the `bodyParameters` array directly into the client send method. Now, the `League\OAuth1\Client\Tool\RequestFactory` uses the `GuzzleHttp\Psr7\Request` constructor to build the request, which does not support array body types. 