### PR TITLE
[2.0] Fixing a couple of issues found during functional testing

### DIFF
--- a/src/Server/AbstractServer.php
+++ b/src/Server/AbstractServer.php
@@ -28,6 +28,7 @@ use League\OAuth1\Client\Exceptions\ConfigurationException;
 use League\OAuth1\Client\Exceptions\CredentialsException;
 use League\OAuth1\Client\Signature\HmacSha1Signature;
 use League\OAuth1\Client\Signature\SignatureInterface;
+use League\OAuth1\Client\Tool\ArrayAccessorTrait;
 use League\OAuth1\Client\Tool\Crypto;
 use League\OAuth1\Client\Tool\RequestFactory;
 use League\OAuth1\Client\Tool\RequestFactoryInterface;
@@ -35,6 +36,8 @@ use Psr\Http\Message\ResponseInterface;
 
 abstract class AbstractServer
 {
+    use ArrayAccessorTrait;
+
     /**
      * Client credentials.
      *
@@ -388,6 +391,7 @@ abstract class AbstractServer
             $this->getAdditionalProtocolParameters(),
             array(
                 'oauth_token' => $credentials->getIdentifier(),
+                'oauth_verifier' => static::getValueByKey($bodyParameters, 'oauth_verifier'),
             )
         );
 
@@ -526,6 +530,10 @@ abstract class AbstractServer
      */
     protected function normalizeProtocolParameters(array $parameters)
     {
+        $parameters = array_filter($parameters, function ($value) {
+            return !empty($value);
+        });
+
         array_walk($parameters, function (&$value, $key) {
             $value = rawurlencode($key).'="'.rawurlencode($value).'"';
         });

--- a/src/Server/AbstractServer.php
+++ b/src/Server/AbstractServer.php
@@ -259,7 +259,7 @@ abstract class AbstractServer
     protected function getBaseProtocolParameters()
     {
         return array(
-            'oauth_consumer_key' => $this->clientCredentials->getIdentifier(),
+            'oauth_consumer_key' => (string) $this->clientCredentials,
             'oauth_nonce' => Crypto::nonce(),
             'oauth_signature_method' => $this->signature->method(),
             'oauth_timestamp' => (new \DateTime())->format('U'),
@@ -462,6 +462,9 @@ abstract class AbstractServer
             $request = $this->getRequestFactory()->getRequest('GET', $uri, $headers);
             $response = $this->getHttpClient()->send($request);
         } catch (BadResponseException $e) {
+            echo "<pre>";
+            print_r($headers);
+            print_r((string) $e->getResponse()->getBody());
             CredentialsException::handleTemporaryCredentialsBadResponse($e);
         }
 
@@ -529,6 +532,8 @@ abstract class AbstractServer
         array_walk($parameters, function (&$value, $key) {
             $value = rawurlencode($key).'="'.rawurlencode($value).'"';
         });
+
+        ksort($parameters);
 
         return 'OAuth '.implode(', ', $parameters);
     }

--- a/src/Server/AbstractServer.php
+++ b/src/Server/AbstractServer.php
@@ -259,7 +259,7 @@ abstract class AbstractServer
     protected function getBaseProtocolParameters()
     {
         return array(
-            'oauth_consumer_key' => (string) $this->clientCredentials,
+            'oauth_consumer_key' => $this->clientCredentials->getIdentifier(),
             'oauth_nonce' => Crypto::nonce(),
             'oauth_signature_method' => $this->signature->method(),
             'oauth_timestamp' => (new \DateTime())->format('U'),
@@ -459,12 +459,9 @@ abstract class AbstractServer
         $headers = $this->buildHttpClientHeaders($authorizationHeader);
 
         try {
-            $request = $this->getRequestFactory()->getRequest('GET', $uri, $headers);
+            $request = $this->getRequestFactory()->getRequest('POST', $uri, $headers);
             $response = $this->getHttpClient()->send($request);
         } catch (BadResponseException $e) {
-            echo "<pre>";
-            print_r($headers);
-            print_r((string) $e->getResponse()->getBody());
             CredentialsException::handleTemporaryCredentialsBadResponse($e);
         }
 

--- a/src/Tool/ArrayAccessorTrait.php
+++ b/src/Tool/ArrayAccessorTrait.php
@@ -1,0 +1,53 @@
+<?php
+
+/**
+ * This file is part of the league/oauth1-client library.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @copyright Copyright (c) Ben Corlett <hello@webcomm.io>
+ * @license http://opensource.org/licenses/MIT MIT
+ *
+ * @link http://thephpleague.com/oauth1-client/ Documentation
+ * @link https://packagist.org/packages/league/oauth1-client Packagist
+ * @link https://github.com/thephpleague/oauth1-client GitHub
+ */
+namespace League\OAuth1\Client\Tool;
+
+/**
+ * Provides generic array navigation tools.
+ */
+trait ArrayAccessorTrait
+{
+    /**
+     * Returns a value by key using dot notation.
+     *
+     * @param  array      $data
+     * @param  string     $key
+     * @param  mixed|null $default
+     * @return mixed
+     */
+    protected static function getValueByKey(array $data, $key, $default = null)
+    {
+        if (!is_string($key) || empty($key) || !count($data)) {
+            return $default;
+        }
+
+        if (strpos($key, '.') !== false) {
+            $keys = explode('.', $key);
+
+            foreach ($keys as $innerKey) {
+                if (!is_array($data) || !array_key_exists($innerKey, $data)) {
+                    return $default;
+                }
+
+                $data = $data[$innerKey];
+            }
+
+            return $data;
+        }
+
+        return array_key_exists($key, $data) ? $data[$key] : $default;
+    }
+}

--- a/test/src/Server/AbstractServerTest.php
+++ b/test/src/Server/AbstractServerTest.php
@@ -339,7 +339,7 @@ class AbstractServerTest extends PHPUnit_Framework_TestCase
 
     public function testGettingTokenCredentials()
     {
-        $headerPattern = '/OAuth oauth_consumer_key=".*?", oauth_nonce="[a-zA-Z0-9]+", oauth_signature=".*?", oauth_signature_method="HMAC-SHA1", oauth_timestamp="\d{10}", oauth_token="temporarycredentialsidentifier", oauth_version="1.0"/';
+        $headerPattern = '/OAuth oauth_consumer_key=".*?", oauth_nonce="[a-zA-Z0-9]+", oauth_signature=".*?", oauth_signature_method="HMAC-SHA1", oauth_timestamp="\d{10}", oauth_token="temporarycredentialsidentifier", oauth_verifier="myverifiercode", oauth_version="1.0"/';
         $payload = 'oauth_token=tokencredentialsidentifier&oauth_token_secret=tokencredentialssecret';
         $request = $this->getRequestMock();
 
@@ -391,7 +391,7 @@ class AbstractServerTest extends PHPUnit_Framework_TestCase
      */
     public function testGettingTokenCredentialsThorwsExceptionOnInvalidResponse()
     {
-        $headerPattern = '/OAuth oauth_consumer_key=".*?", oauth_nonce="[a-zA-Z0-9]+", oauth_signature=".*?", oauth_signature_method="HMAC-SHA1", oauth_timestamp="\d{10}", oauth_token="temporarycredentialsidentifier", oauth_version="1.0"/';
+        $headerPattern = '/OAuth oauth_consumer_key=".*?", oauth_nonce="[a-zA-Z0-9]+", oauth_signature=".*?", oauth_signature_method="HMAC-SHA1", oauth_timestamp="\d{10}", oauth_token="temporarycredentialsidentifier", oauth_verifier="myverifiercode", oauth_version="1.0"/';
         $payload = '';
         $request = $this->getRequestMock();
 
@@ -416,7 +416,7 @@ class AbstractServerTest extends PHPUnit_Framework_TestCase
      */
     public function testGettingTokenCredentialsThorwsExceptionOnErrorInResponse()
     {
-        $headerPattern = '/OAuth oauth_consumer_key=".*?", oauth_nonce="[a-zA-Z0-9]+", oauth_signature=".*?", oauth_signature_method="HMAC-SHA1", oauth_timestamp="\d{10}", oauth_token="temporarycredentialsidentifier", oauth_version="1.0"/';
+        $headerPattern = '/OAuth oauth_consumer_key=".*?", oauth_nonce="[a-zA-Z0-9]+", oauth_signature=".*?", oauth_signature_method="HMAC-SHA1", oauth_timestamp="\d{10}", oauth_token="temporarycredentialsidentifier", oauth_verifier="myverifiercode", oauth_version="1.0"/';
         $payload = 'error=foo';
         $request = $this->getRequestMock();
 
@@ -438,7 +438,7 @@ class AbstractServerTest extends PHPUnit_Framework_TestCase
 
     public function testGettingTokenCredentialsWithUserAgent()
     {
-        $headerPattern = '/OAuth oauth_consumer_key=".*?", oauth_nonce="[a-zA-Z0-9]+", oauth_signature=".*?", oauth_signature_method="HMAC-SHA1", oauth_timestamp="\d{10}", oauth_token="temporarycredentialsidentifier", oauth_version="1.0"/';
+        $headerPattern = '/OAuth oauth_consumer_key=".*?", oauth_nonce="[a-zA-Z0-9]+", oauth_signature=".*?", oauth_signature_method="HMAC-SHA1", oauth_timestamp="\d{10}", oauth_token="temporarycredentialsidentifier", oauth_verifier="myverifiercode", oauth_version="1.0"/';
         $userAgent = 'FooBar';
         $payload = 'oauth_token=tokencredentialsidentifier&oauth_token_secret=tokencredentialssecret';
         $request = $this->getRequestMock();

--- a/test/src/Server/AbstractServerTest.php
+++ b/test/src/Server/AbstractServerTest.php
@@ -63,9 +63,9 @@ class AbstractServerTest extends PHPUnit_Framework_TestCase
         );
     }
 
-    protected function getRequestMock()
+    protected function getRequestMock($method = 'GET')
     {
-        $request = RequestFactory::getRequest('GET', 'http://foo.bar');
+        $request = RequestFactory::getRequest($method, 'http://foo.bar');
 
         return $request;
     }
@@ -137,6 +137,9 @@ class AbstractServerTest extends PHPUnit_Framework_TestCase
     protected function isTempAuthenticatedRequest($pattern, $headers, $userAgent = null)
     {
         $this->assertTrue(isset($headers['Authorization']));
+        if (is_array($headers['Authorization'])) {
+            $headers['Authorization'] = $headers['Authorization'][0];
+        }
         $matches = preg_match($pattern, $headers['Authorization']);
         $this->assertEquals(1, $matches, 'Asserting that the authorization header contains the correct expression.');
 
@@ -246,18 +249,18 @@ class AbstractServerTest extends PHPUnit_Framework_TestCase
 
     public function testGettingTemporaryCredentials()
     {
-        $headerPattern = '/OAuth oauth_consumer_key=".*?", oauth_nonce="[a-zA-Z0-9]+", oauth_signature_method="HMAC-SHA1", oauth_timestamp="\d{10}", oauth_version="1.0", oauth_callback="'.preg_quote('http%3A%2F%2Fapp.dev%2F', '/').'", oauth_signature=".*?"/';
+        $headerPattern = '/OAuth oauth_callback="'.preg_quote('http%3A%2F%2Fapp.dev%2F', '/').'", oauth_consumer_key=".*?", oauth_nonce="[a-zA-Z0-9]+", oauth_signature=".*?", oauth_signature_method="HMAC-SHA1", oauth_timestamp="\d{10}", oauth_version="1.0"/';
         $payload = 'oauth_token=temporarycredentialsidentifier&oauth_token_secret=temporarycredentialssecret&oauth_callback_confirmed=true';
-        $request = $this->getRequestMock();
+        $request = $this->getRequestMock('POST');
 
-        $requestFactory = m::mock(RequestFactoryInterface::class);
-        $requestFactory->shouldReceive('getRequest')->with('GET', 'http://your.service/temporary-credentials', m::on(function ($headers) use ($headerPattern) {
-            return $this->isTempAuthenticatedRequest($headerPattern, $headers);
-        }))->once()->andReturn($request);
+        $httpClient = $this->getHttpClientMock(m::on(function ($request) use ($headerPattern) {
+            $this->assertEquals('POST', $request->getMethod());
+            $this->assertArrayHasKey('Authorization', $request->getHeaders());
 
-        $httpClient = $this->getHttpClientMock($request, $payload);
+            return $this->isTempAuthenticatedRequest($headerPattern, $request->getHeaders());
+        }), $payload);
 
-        $collaborators = ['httpClient' => $httpClient, 'requestFactory' => $requestFactory];
+        $collaborators = ['httpClient' => $httpClient];
 
         $server = $this->getServerMock($collaborators);
 
@@ -275,7 +278,7 @@ class AbstractServerTest extends PHPUnit_Framework_TestCase
         $request = $this->getRequestMock();
 
         $requestFactory = m::mock(RequestFactoryInterface::class);
-        $requestFactory->shouldReceive('getRequest')->with('GET', 'http://your.service/temporary-credentials', m::on(function ($headers) {
+        $requestFactory->shouldReceive('getRequest')->with('POST', 'http://your.service/temporary-credentials', m::on(function ($headers) {
             return is_array($headers);
         }))->once()->andReturn($request);
 
@@ -293,12 +296,12 @@ class AbstractServerTest extends PHPUnit_Framework_TestCase
      */
     public function testGettingTemporaryCredentialsThrowsExceptionOnInvalidResponse()
     {
-        $headerPattern = '/OAuth oauth_consumer_key=".*?", oauth_nonce="[a-zA-Z0-9]+", oauth_signature_method="HMAC-SHA1", oauth_timestamp="\d{10}", oauth_version="1.0", oauth_callback="'.preg_quote('http%3A%2F%2Fapp.dev%2F', '/').'", oauth_signature=".*?"/';
+        $headerPattern = '/OAuth oauth_callback="'.preg_quote('http%3A%2F%2Fapp.dev%2F', '/').'", oauth_consumer_key=".*?", oauth_nonce="[a-zA-Z0-9]+", oauth_signature=".*?", oauth_signature_method="HMAC-SHA1", oauth_timestamp="\d{10}", oauth_version="1.0"/';
         $payload = '';
         $request = $this->getRequestMock();
 
         $requestFactory = m::mock(RequestFactoryInterface::class);
-        $requestFactory->shouldReceive('getRequest')->with('GET', 'http://your.service/temporary-credentials', m::on(function ($headers) use ($headerPattern) {
+        $requestFactory->shouldReceive('getRequest')->with('POST', 'http://your.service/temporary-credentials', m::on(function ($headers) use ($headerPattern) {
             return $this->isTempAuthenticatedRequest($headerPattern, $headers);
         }))->once()->andReturn($request);
 
@@ -316,12 +319,12 @@ class AbstractServerTest extends PHPUnit_Framework_TestCase
      */
     public function testGettingTemporaryCredentialsThrowsExceptionOnMissingOauthKeys()
     {
-        $headerPattern = '/OAuth oauth_consumer_key=".*?", oauth_nonce="[a-zA-Z0-9]+", oauth_signature_method="HMAC-SHA1", oauth_timestamp="\d{10}", oauth_version="1.0", oauth_callback="'.preg_quote('http%3A%2F%2Fapp.dev%2F', '/').'", oauth_signature=".*?"/';
+        $headerPattern = '/OAuth oauth_callback="'.preg_quote('http%3A%2F%2Fapp.dev%2F', '/').'", oauth_consumer_key=".*?", oauth_nonce="[a-zA-Z0-9]+", oauth_signature=".*?", oauth_signature_method="HMAC-SHA1", oauth_timestamp="\d{10}", oauth_version="1.0"/';
         $payload = 'foo=bar';
         $request = $this->getRequestMock();
 
         $requestFactory = m::mock(RequestFactoryInterface::class);
-        $requestFactory->shouldReceive('getRequest')->with('GET', 'http://your.service/temporary-credentials', m::on(function ($headers) use ($headerPattern) {
+        $requestFactory->shouldReceive('getRequest')->with('POST', 'http://your.service/temporary-credentials', m::on(function ($headers) use ($headerPattern) {
             return $this->isTempAuthenticatedRequest($headerPattern, $headers);
         }))->once()->andReturn($request);
 
@@ -336,7 +339,7 @@ class AbstractServerTest extends PHPUnit_Framework_TestCase
 
     public function testGettingTokenCredentials()
     {
-        $headerPattern = '/OAuth oauth_consumer_key=".*?", oauth_nonce="[a-zA-Z0-9]+", oauth_signature_method="HMAC-SHA1", oauth_timestamp="\d{10}", oauth_version="1.0", oauth_token="temporarycredentialsidentifier", oauth_signature=".*?"/';
+        $headerPattern = '/OAuth oauth_consumer_key=".*?", oauth_nonce="[a-zA-Z0-9]+", oauth_signature=".*?", oauth_signature_method="HMAC-SHA1", oauth_timestamp="\d{10}", oauth_token="temporarycredentialsidentifier", oauth_version="1.0"/';
         $payload = 'oauth_token=tokencredentialsidentifier&oauth_token_secret=tokencredentialssecret';
         $request = $this->getRequestMock();
 
@@ -388,7 +391,7 @@ class AbstractServerTest extends PHPUnit_Framework_TestCase
      */
     public function testGettingTokenCredentialsThorwsExceptionOnInvalidResponse()
     {
-        $headerPattern = '/OAuth oauth_consumer_key=".*?", oauth_nonce="[a-zA-Z0-9]+", oauth_signature_method="HMAC-SHA1", oauth_timestamp="\d{10}", oauth_version="1.0", oauth_token="temporarycredentialsidentifier", oauth_signature=".*?"/';
+        $headerPattern = '/OAuth oauth_consumer_key=".*?", oauth_nonce="[a-zA-Z0-9]+", oauth_signature=".*?", oauth_signature_method="HMAC-SHA1", oauth_timestamp="\d{10}", oauth_token="temporarycredentialsidentifier", oauth_version="1.0"/';
         $payload = '';
         $request = $this->getRequestMock();
 
@@ -413,7 +416,7 @@ class AbstractServerTest extends PHPUnit_Framework_TestCase
      */
     public function testGettingTokenCredentialsThorwsExceptionOnErrorInResponse()
     {
-        $headerPattern = '/OAuth oauth_consumer_key=".*?", oauth_nonce="[a-zA-Z0-9]+", oauth_signature_method="HMAC-SHA1", oauth_timestamp="\d{10}", oauth_version="1.0", oauth_token="temporarycredentialsidentifier", oauth_signature=".*?"/';
+        $headerPattern = '/OAuth oauth_consumer_key=".*?", oauth_nonce="[a-zA-Z0-9]+", oauth_signature=".*?", oauth_signature_method="HMAC-SHA1", oauth_timestamp="\d{10}", oauth_token="temporarycredentialsidentifier", oauth_version="1.0"/';
         $payload = 'error=foo';
         $request = $this->getRequestMock();
 
@@ -435,7 +438,7 @@ class AbstractServerTest extends PHPUnit_Framework_TestCase
 
     public function testGettingTokenCredentialsWithUserAgent()
     {
-        $headerPattern = '/OAuth oauth_consumer_key=".*?", oauth_nonce="[a-zA-Z0-9]+", oauth_signature_method="HMAC-SHA1", oauth_timestamp="\d{10}", oauth_version="1.0", oauth_token="temporarycredentialsidentifier", oauth_signature=".*?"/';
+        $headerPattern = '/OAuth oauth_consumer_key=".*?", oauth_nonce="[a-zA-Z0-9]+", oauth_signature=".*?", oauth_signature_method="HMAC-SHA1", oauth_timestamp="\d{10}", oauth_token="temporarycredentialsidentifier", oauth_version="1.0"/';
         $userAgent = 'FooBar';
         $payload = 'oauth_token=tokencredentialsidentifier&oauth_token_secret=tokencredentialssecret';
         $request = $this->getRequestMock();
@@ -462,7 +465,7 @@ class AbstractServerTest extends PHPUnit_Framework_TestCase
 
     public function testGettingUserDetails()
     {
-        $headerPattern = '/OAuth oauth_consumer_key=".*?", oauth_nonce="[a-zA-Z0-9]+", oauth_signature_method="HMAC-SHA1", oauth_timestamp="\d{10}", oauth_version="1.0", oauth_token="tokencredentialsidentifier", oauth_signature=".*?"/';
+        $headerPattern = '/OAuth oauth_consumer_key=".*?", oauth_nonce="[a-zA-Z0-9]+", oauth_signature=".*?", oauth_signature_method="HMAC-SHA1", oauth_timestamp="\d{10}", oauth_token="tokencredentialsidentifier", oauth_version="1.0"/';
         $userData = ['foo' => 'bar', 'id' => 123, 'contact_email' => 'baz@qux.com', 'username' => 'fred'];
         $payload = json_encode($userData);
         $request = $this->getRequestMock();
@@ -515,7 +518,7 @@ class AbstractServerTest extends PHPUnit_Framework_TestCase
         // OAuth protocol specifies a strict number of
         // headers should be sent, in the correct order.
         // We'll validate that here.
-        $pattern = '/OAuth oauth_consumer_key=".*?", oauth_nonce="[a-zA-Z0-9]+", oauth_signature_method="HMAC-SHA1", oauth_timestamp="\d{10}", oauth_version="1.0", oauth_token="tokencredentialsidentifier", oauth_signature=".*?"/';
+        $pattern = '/OAuth oauth_consumer_key=".*?", oauth_nonce="[a-zA-Z0-9]+", oauth_signature=".*?", oauth_signature_method="HMAC-SHA1", oauth_timestamp="\d{10}", oauth_token="tokencredentialsidentifier", oauth_version="1.0"/';
 
         $tokenCredentials = $this->getTokenCredentialsMock();
 
@@ -536,7 +539,7 @@ class AbstractServerTest extends PHPUnit_Framework_TestCase
 
     public function testGettingAuthenticatedRequest()
     {
-        $headerPattern = '/OAuth oauth_consumer_key=".*?", oauth_nonce="[a-zA-Z0-9]+", oauth_signature_method="HMAC-SHA1", oauth_timestamp="\d{10}", oauth_version="1.0", oauth_token="tokencredentialsidentifier", oauth_signature=".*?"/';
+        $headerPattern = '/OAuth oauth_consumer_key=".*?", oauth_nonce="[a-zA-Z0-9]+", oauth_signature=".*?", oauth_signature_method="HMAC-SHA1", oauth_timestamp="\d{10}", oauth_token="tokencredentialsidentifier", oauth_version="1.0"/';
         $url = 'foo';
         $method = 'bar';
 

--- a/test/src/Tool/ArrayAccessorTraitTest.php
+++ b/test/src/Tool/ArrayAccessorTraitTest.php
@@ -1,0 +1,60 @@
+<?php
+/**
+ * This file is part of the league/oauth1-client library
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @copyright Copyright (c) Ben Corlett <hello@webcomm.io>
+ * @license http://opensource.org/licenses/MIT MIT
+ * @link http://thephpleague.com/oauth1-client/ Documentation
+ * @link https://packagist.org/packages/league/oauth1-client Packagist
+ * @link https://github.com/thephpleague/oauth1-client GitHub
+ */
+
+namespace League\OAuth1\Client\Tests\Tool;
+
+use League\OAuth1\Client\Tool\ArrayAccessorTrait;
+use PHPUnit_Framework_TestCase;
+
+class ArrayAccessorTraitTest extends PHPUnit_Framework_TestCase
+{
+    use ArrayAccessorTrait;
+
+    public function testGetRootValue()
+    {
+        $array = ['foo' => 'bar'];
+
+        $result = static::getValueByKey($array, 'foo');
+
+        $this->assertEquals($array['foo'], $result);
+    }
+
+    public function testGetNonExistentValueWithDefault()
+    {
+        $array = [];
+        $default = 'foo';
+
+        $result = static::getValueByKey($array, 'bar', $default);
+
+        $this->assertEquals($default, $result);
+    }
+
+    public function testGetNestedValue()
+    {
+        $array = ['foo' => ['bar' => 'murray']];
+
+        $result = static::getValueByKey($array, 'foo.bar');
+
+        $this->assertEquals($array['foo']['bar'], $result);
+    }
+
+    public function testGetNonExistantRootValue()
+    {
+        $array = ['foo' => 'bar'];
+
+        $result = static::getValueByKey($array, 'foo.bar');
+
+        $this->assertNull($result);
+    }
+}


### PR DESCRIPTION
The temporary credentials method needs to be POST and I added a ksort to the OAuth Authorization header key-value pairs. 