### PR TITLE
[2.0] Update inheritDoc tags to correct format

### DIFF
--- a/src/Credentials/Credentials.php
+++ b/src/Credentials/Credentials.php
@@ -44,7 +44,7 @@ abstract class Credentials
     }
 
     /**
-     * {@inheritdoc}
+     * @inheritdoc
      */
     public function getIdentifier()
     {
@@ -52,7 +52,7 @@ abstract class Credentials
     }
 
     /**
-     * {@inheritdoc}
+     * @inheritdoc
      */
     public function getSecret()
     {

--- a/src/Server/GenericResourceOwner.php
+++ b/src/Server/GenericResourceOwner.php
@@ -37,7 +37,7 @@ class GenericResourceOwner implements IteratorAggregate, ResourceOwnerInterface
     }
 
     /**
-     * {@inheritdoc}
+     * @inheritdoc
      */
     public function getIterator()
     {

--- a/src/Server/GenericServer.php
+++ b/src/Server/GenericServer.php
@@ -49,7 +49,7 @@ class GenericServer extends AbstractServer
     protected $resourceOwnerDetailsUri;
 
     /**
-     * {@inheritdoc}
+     * @inheritdoc
      */
     protected function getBaseTemporaryCredentialsUrl()
     {
@@ -57,7 +57,7 @@ class GenericServer extends AbstractServer
     }
 
     /**
-     * {@inheritdoc}
+     * @inheritdoc
      */
     protected function getBaseAuthorizationUrl()
     {
@@ -65,7 +65,7 @@ class GenericServer extends AbstractServer
     }
 
     /**
-     * {@inheritdoc}
+     * @inheritdoc
      */
     protected function getBaseTokenCredentialsUrl()
     {
@@ -73,7 +73,7 @@ class GenericServer extends AbstractServer
     }
 
     /**
-     * {@inheritdoc}
+     * @inheritdoc
      */
     protected function getResourceOwnerDetailsUrl(TokenCredentials $tokenCredentials)
     {
@@ -81,15 +81,15 @@ class GenericServer extends AbstractServer
     }
 
     /**
-     * {@inheritdoc}
+     * @inheritdoc
      */
     protected function checkResponse(ResponseInterface $response, $data)
     {
-        //
+
     }
 
     /**
-     * {@inheritdoc}
+     * @inheritdoc
      */
     protected function createResourceOwner(array $response, TokenCredentials $tokenCredentials)
     {

--- a/src/Signature/HmacSha1Signature.php
+++ b/src/Signature/HmacSha1Signature.php
@@ -18,7 +18,7 @@ namespace League\OAuth1\Client\Signature;
 class HmacSha1Signature extends Signature implements SignatureInterface
 {
     /**
-     * {@inheritdoc}
+     * @inheritdoc
      */
     public function method()
     {
@@ -26,7 +26,7 @@ class HmacSha1Signature extends Signature implements SignatureInterface
     }
 
     /**
-     * {@inheritdoc}
+     * @inheritdoc
      */
     public function sign($uri, array $parameters = array(), $method = 'POST')
     {

--- a/src/Signature/PlainTextSignature.php
+++ b/src/Signature/PlainTextSignature.php
@@ -18,7 +18,7 @@ namespace League\OAuth1\Client\Signature;
 class PlainTextSignature extends Signature implements SignatureInterface
 {
     /**
-     * {@inheritdoc}
+     * @inheritdoc
      */
     public function method()
     {
@@ -26,7 +26,7 @@ class PlainTextSignature extends Signature implements SignatureInterface
     }
 
     /**
-     * {@inheritdoc}
+     * @inheritdoc
      */
     public function sign($uri, array $parameters = array(), $method = 'POST')
     {

--- a/src/Signature/Signature.php
+++ b/src/Signature/Signature.php
@@ -35,7 +35,9 @@ abstract class Signature implements SignatureInterface
     protected $credentials;
 
     /**
-     * {@inheritdoc}
+     * Creates signature instance.
+     *
+     * @param ClientCredentials  $clientCredentials
      */
     public function __construct(ClientCredentials $clientCredentials)
     {
@@ -43,7 +45,7 @@ abstract class Signature implements SignatureInterface
     }
 
     /**
-     * {@inheritdoc}
+     * @inheritdoc
      */
     public function setCredentials(Credentials $credentials)
     {


### PR DESCRIPTION
As @shadowhand pointed out in #40 the inline `{@inheritdoc}` only inherits the summary.

Also, the `League\OAuth1\Client\Signature\Signature::__construct` method had a doc inheritance tag. Where is it inheriting from!? :smile: 