### PR TITLE
[2.0] Clean up exception factory handling

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -15,8 +15,8 @@
   <logging>
         <log type="tap" target="build/report.tap"/>
         <log type="junit" target="build/report.junit.xml"/>
+        <log type="coverage-text" target="php://stdout"/>
         <log type="coverage-html" target="build/coverage" charset="UTF-8" yui="true" highlight="true"/>
-        <log type="coverage-text" target="build/coverage.txt"/>
         <log type="coverage-clover" target="build/logs/clover.xml"/>
     </logging>
 </phpunit>

--- a/src/Credentials/ClientCredentials.php
+++ b/src/Credentials/ClientCredentials.php
@@ -53,8 +53,8 @@ class ClientCredentials extends Credentials
     {
         array_map(function ($required) use ($options) {
             if (!array_key_exists($required, $options)) {
-                ConfigurationException::handleMissingRequiredOption($required);
-            } // @codeCoverageIgnore
+                throw ConfigurationException::missingRequiredOption($required);
+            }
         }, ['identifier', 'secret', 'callbackUri']);
 
         return new static(

--- a/src/Credentials/TemporaryCredentials.php
+++ b/src/Credentials/TemporaryCredentials.php
@@ -33,8 +33,8 @@ class TemporaryCredentials extends Credentials
     public function checkIdentifier($identifier)
     {
         if ($identifier !== $this->getIdentifier()) {
-            ConfigurationException::handleTemporaryIdentifierMismatch();
-        } // @codeCoverageIgnore
+            throw ConfigurationException::temporaryIdentifierMismatch();
+        }
     }
 
     /**
@@ -50,16 +50,16 @@ class TemporaryCredentials extends Credentials
         parse_str($response->getBody(), $data);
 
         if (!$data || !is_array($data)) {
-            CredentialsException::handleResponseParseError('temporary');
-        } // @codeCoverageIgnore
+            throw CredentialsException::responseParseError('temporary');
+        }
 
         if (!isset($data['oauth_callback_confirmed']) || $data['oauth_callback_confirmed'] != 'true') {
             $defaultError = 'OAuth keys missing from successful temporary credentials payload.';
 
-            CredentialsException::handleTemporaryCredentialsRetrievalError(
+            throw CredentialsException::temporaryCredentialsRetrievalError(
                 (isset($data['error']) ? $data['error'] : $defaultError)
             );
-        } // @codeCoverageIgnore
+        }
 
         return new static(
             $data['oauth_token'],

--- a/src/Credentials/TokenCredentials.php
+++ b/src/Credentials/TokenCredentials.php
@@ -23,22 +23,23 @@ class TokenCredentials extends Credentials
     /**
      * Creates token credentials from a given response.
      *
-     * @param Psr\Http\Message\ResponseInterface $response
+     * @param ResponseInterface $response
      *
      * @return TokenCredentials
-     * @throws League\OAuth1\Client\Exceptions\CredentialsException
+     *
+     * @throws CredentialsException
      */
     public static function createFromResponse(ResponseInterface $response)
     {
         parse_str($response->getBody(), $data);
 
         if (!$data || !is_array($data)) {
-            CredentialsException::handleResponseParseError('token');
-        } // @codeCoverageIgnore
+            throw CredentialsException::responseParseError('token');
+        }
 
         if (isset($data['error'])) {
-            CredentialsException::handleTokenCredentialsRetrievalError($data['error']);
-        } // @codeCoverageIgnore
+            throw CredentialsException::tokenCredentialsRetrievalError($data['error']);
+        }
 
         return new static(
             $data['oauth_token'],

--- a/src/Exceptions/ConfigurationException.php
+++ b/src/Exceptions/ConfigurationException.php
@@ -20,35 +20,43 @@ class ConfigurationException extends Exception
     /**
      * Handles an invalid response type.
      *
-     * @param  string  $responseType
+     * @param string $responseType
      *
-     * @throws ConfigurationException
+     * @return static
      */
-    public static function handleInvalidResponseType($responseType)
+    public static function invalidResponseType($responseType)
     {
-        throw new static("Invalid response type [{$responseType}].");
+        return new static(sprintf(
+            'Invalid response type `%s`.',
+            $responseType
+        ));
     }
 
     /**
      * Handles a missing required option.
      *
-     * @param  string  $requiredOption
+     * @param string $requiredOption
      *
-     * @throws ConfigurationException
+     * @return static
      */
-    public static function handleMissingRequiredOption($requiredOption)
+    public static function missingRequiredOption($requiredOption)
     {
-        throw new static("Expected {$requiredOption} option to create client credentials.");
+        return new static(sprintf(
+            'Expected `%s` option to create client credentials.',
+            $requiredOption
+        ));
     }
 
     /**
      * Handles a temporary identifier mismatch.
      *
-     * @throws ConfigurationException
+     * @return ConfigurationException
      */
-    public static function handleTemporaryIdentifierMismatch()
+    public static function temporaryIdentifierMismatch()
     {
-        throw new static('Temporary identifier passed back by server does not match
-            that of stored temporary credentials. Potential man-in-the-middle.');
+        return new static(
+            'Temporary identifier passed back by server does not match that of ' .
+            'stored temporary credentials. Potential man-in-the-middle.'
+        );
     }
 }

--- a/src/Exceptions/CredentialsException.php
+++ b/src/Exceptions/CredentialsException.php
@@ -22,70 +22,80 @@ class CredentialsException extends Exception
     /**
      * Handles an error in parsing credentials from a given response.
      *
-     * @param  string  $type Type of credentials
+     * @param string $type Type of credentials
      *
-     * @throws CredentialsException
+     * @return static
      */
-    public static function handleResponseParseError($type)
+    public static function responseParseError($type)
     {
-        throw new static("Unable to parse $type credentials response.");
+        return new static(sprintf(
+            'Unable to parse `%s` credentials response.',
+            $type
+        ));
     }
 
     /**
      * Handles a bad response coming back when getting temporary credentials.
      *
-     * @param GuzzleHttp\Exception\BadResponseException $e
+     * @param BadResponseException $e
      *
-     * @throws CredentialsException
+     * @return static
      */
-    public static function handleTemporaryCredentialsBadResponse(BadResponseException $e)
+    public static function temporaryCredentialsBadResponse(BadResponseException $e)
     {
         $response = $e->getResponse();
         $body = $response->getBody();
         $statusCode = $response->getStatusCode();
 
-        throw new static(
-            "Received HTTP status code [$statusCode] with message \"$body\" when getting temporary credentials."
-        );
+        return new static(sprintf(
+            'Received HTTP status code [%d] with message "%s" when getting temporary credentials.',
+            $statusCode,
+            $body
+        ));
     }
 
     /**
      * Handles an error in retrieving credentials from a resource.
      *
-     * @throws CredentialsException
+     * @return static
      */
-    public static function handleTemporaryCredentialsRetrievalError()
+    public static function temporaryCredentialsRetrievalError()
     {
-        throw new static('Error in retrieving temporary credentials.');
+        return new static('Error in retrieving temporary credentials.');
     }
 
     /**
      * Handles a bad response coming back when getting token credentials.
      *
-     * @param GuzzleHttp\Exception\BadResponseException $e
+     * @param BadResponseException $e
      *
-     * @throws CredentialsException
+     * @return static
      */
-    public static function handleTokenCredentialsBadResponse(BadResponseException $e)
+    public static function tokenCredentialsBadResponse(BadResponseException $e)
     {
         $response = $e->getResponse();
         $body = $response->getBody();
         $statusCode = $response->getStatusCode();
 
-        throw new static(
-            "Received HTTP status code [$statusCode] with message \"$body\" when getting token credentials."
-        );
+        return new static(sprintf(
+            'Received HTTP status code [%d] with message "%s" when getting token credentials.',
+            $statusCode,
+            $body
+        ));
     }
 
     /**
      * Handles an error in retrieving credentials from a resource.
      *
-     * @param  string  $error Error message from resource
+     * @param string $error Error message from resource
      *
-     * @throws CredentialsException
+     * @return static
      */
-    public static function handleTokenCredentialsRetrievalError($error)
+    public static function tokenCredentialsRetrievalError($error)
     {
-        throw new static("Error [{$error}] in retrieving token credentials.");
+        return new static(sprintf(
+            'Error "%s" in retrieving token credentials.',
+            $error
+        ));
     }
 }

--- a/src/Server/AbstractServer.php
+++ b/src/Server/AbstractServer.php
@@ -450,6 +450,8 @@ abstract class AbstractServer
      * the server.
      *
      * @return TemporaryCredentials
+     *
+     * @throws CredentialsException If the request failed
      */
     public function getTemporaryCredentials()
     {
@@ -462,7 +464,7 @@ abstract class AbstractServer
             $request = $this->getRequestFactory()->getRequest('GET', $uri, $headers);
             $response = $this->getHttpClient()->send($request);
         } catch (BadResponseException $e) {
-            CredentialsException::handleTemporaryCredentialsBadResponse($e);
+            throw CredentialsException::temporaryCredentialsBadResponse($e);
         }
 
         return TemporaryCredentials::createFromResponse($response);
@@ -497,6 +499,8 @@ abstract class AbstractServer
      * @param string               $verifier
      *
      * @return TokenCredentials
+     *
+     * @throws CredentialsException If the request failed
      */
     public function getTokenCredentials(TemporaryCredentials $temporaryCredentials, $temporaryIdentifier, $verifier)
     {
@@ -510,7 +514,7 @@ abstract class AbstractServer
             $request = $this->getRequestFactory()->getRequest('POST', $uri, $headers, $body);
             $response = $this->getHttpClient()->send($request);
         } catch (BadResponseException $e) {
-            CredentialsException::handleTokenCredentialsBadResponse($e);
+            throw CredentialsException::tokenCredentialsBadResponse($e);
         }
 
         return TokenCredentials::createFromResponse($response);
@@ -555,7 +559,7 @@ abstract class AbstractServer
                 parse_str($response->getBody(), $this->cachedUserDetailsResponse);
                 break;
             default:
-                ConfigurationException::handleInvalidResponseType($this->responseType);
+                throw ConfigurationException::invalidResponseType($this->responseType);
         }
     }
 

--- a/test/src/Exceptions/ExceptionsTest.php
+++ b/test/src/Exceptions/ExceptionsTest.php
@@ -52,42 +52,34 @@ class ExceptionsTest extends PHPUnit_Framework_TestCase
     {
         $responseType = 'foo';
 
-        try {
-            ConfigurationException::handleInvalidResponseType($responseType);
-        } catch (ConfigurationException $e) {
-            $this->assertContains($responseType, $e->getMessage());
-        }
+        $exception = ConfigurationException::invalidResponseType($responseType);
+
+        $this->assertContains($responseType, $exception->getMessage());
     }
 
     public function testConfigurationExceptionHandlesMissingRequiredOption()
     {
         $requiredOption = 'foo';
 
-        try {
-            ConfigurationException::handleMissingRequiredOption($requiredOption);
-        } catch (ConfigurationException $e) {
-            $this->assertContains($requiredOption, $e->getMessage());
-        }
+        $exception = ConfigurationException::missingRequiredOption($requiredOption);
+
+        $this->assertContains($requiredOption, $exception->getMessage());
     }
 
     public function testConfigurationExceptionHandlesTemporaryIdentifierMismatch()
     {
-        try {
-            ConfigurationException::handleTemporaryIdentifierMismatch();
-        } catch (ConfigurationException $e) {
-            $this->assertContains('man-in-the-middle', $e->getMessage());
-        }
+        $exception = ConfigurationException::temporaryIdentifierMismatch();
+
+        $this->assertContains('man-in-the-middle', $exception->getMessage());
     }
 
     public function testCredentialsExceptionHandlesResponseParseError()
     {
         $type = 'foo';
 
-        try {
-            CredentialsException::handleResponseParseError($type);
-        } catch (CredentialsException $e) {
-            $this->assertContains($type, $e->getMessage());
-        }
+        $exception = CredentialsException::responseParseError($type);
+
+        $this->assertContains($type, $exception->getMessage());
     }
 
     public function testCredentialsExceptionHandlesTemporaryCredentialsBadResponse()
@@ -96,21 +88,17 @@ class ExceptionsTest extends PHPUnit_Framework_TestCase
         $statusCode = '400';
         $exception = $this->getBadResponseException($body, $statusCode);
 
-        try {
-            CredentialsException::handleTemporaryCredentialsBadResponse($exception);
-        } catch (CredentialsException $e) {
-            $this->assertContains($body, $e->getMessage());
-            $this->assertContains($statusCode, $e->getMessage());
-        }
+        $exception = CredentialsException::temporaryCredentialsBadResponse($exception);
+
+        $this->assertContains($body, $exception->getMessage());
+        $this->assertContains($statusCode, $exception->getMessage());
     }
 
     public function testCredentialsExceptionHandlesTemporaryCredentialsRetrievalError()
     {
-        try {
-            CredentialsException::handleTemporaryCredentialsRetrievalError();
-        } catch (CredentialsException $e) {
-            $this->assertContains('Error in retrieving temporary credentials.', $e->getMessage());
-        }
+        $exception = CredentialsException::temporaryCredentialsRetrievalError();
+
+        $this->assertContains('Error in retrieving temporary credentials.', $exception->getMessage());
     }
 
     public function testCredentialsExceptionHandlesTokenCredentialsBadResponse()
@@ -119,22 +107,17 @@ class ExceptionsTest extends PHPUnit_Framework_TestCase
         $statusCode = '400';
         $exception = $this->getBadResponseException($body, $statusCode);
 
-        try {
-            CredentialsException::handleTokenCredentialsBadResponse($exception);
-        } catch (CredentialsException $e) {
-            $this->assertContains($body, $e->getMessage());
-            $this->assertContains($statusCode, $e->getMessage());
-        }
+        $exception = CredentialsException::tokenCredentialsBadResponse($exception);
+
+        $this->assertContains($body, $exception->getMessage());
+        $this->assertContains($statusCode, $exception->getMessage());
     }
 
     public function testCredentialsExceptionHandlesTokenCredentialsRetrievalError()
     {
         $error = 'foo';
 
-        try {
-            CredentialsException::handleTokenCredentialsRetrievalError($error);
-        } catch (CredentialsException $e) {
-            $this->assertContains($error, $e->getMessage());
-        }
+        $exception = CredentialsException::tokenCredentialsRetrievalError($error);
+        $this->assertContains($error, $exception->getMessage());
     }
 }


### PR DESCRIPTION
Instead of having the exceptions throw themselves, return the exception
instance and let the calling class throw it. This ensures the calling
class retains control and allows code coverage to operate normally.