### PR TITLE
Allow mult-dimension arrays when generating base string for HMAC-SHA1 signature. Fixes #39

### DIFF
--- a/src/Client/Signature/HmacSha1Signature.php
+++ b/src/Client/Signature/HmacSha1Signature.php
@@ -62,17 +62,52 @@ class HmacSha1Signature extends Signature implements SignatureInterface
 
         $data = array();
         parse_str($url->getQuery(), $query);
-        foreach (array_merge($query, $parameters) as $key => $value) {
-            $data[rawurlencode($key)] = rawurlencode($value);
-        }
+        $data = array_merge($query, $parameters);
 
-        ksort($data);
-        array_walk($data, function (&$value, $key) {
-            $value = $key.'='.$value;
+        // normalize data key/values
+        array_walk_recursive($data, function (&$key, &$value) {
+            $key   = rawurlencode(rawurldecode($key));
+            $value = rawurlencode(rawurldecode($value));
         });
-        $baseString .= rawurlencode(implode('&', $data));
+        ksort( $data );
+
+        $baseString .= $this->queryStringFromData($data);
 
         return $baseString;
+    }
+
+    /**
+     * Creates an array of urlencoded strings out of each array key/value pair
+     * Handles multi-demensional arrays recursively.
+     *
+     * @param  array  $data        Array of parameters to convert.
+     * @param  array  $queryParams Array to extend. False by default.
+     * @param  string $prevKey     Optional Array key to append
+     *
+     * @return string              urlencoded string version of data
+     */
+    protected function queryStringFromData($data, $queryParams = false, $prevKey = '')
+    {
+        if ($initial = (false === $queryParams)) {
+            $queryParams = array();
+        }
+
+        foreach ($data as $key => $value) {
+            if (is_array($value)) {
+                $queryParams = $this->queryStringFromData($value, $queryParams, $key);
+            } else {
+                if ($prevKey) {
+                    $key = $prevKey.'['.$key.']'; // Handle multi-dimensional array
+                }
+                $queryParams[] = urlencode($key.'='.$value); // join with equals sign
+            }
+        }
+
+        if ($initial) {
+            return implode('%26',$queryParams); // join with ampersand
+        }
+
+        return $queryParams;
     }
 
     /**


### PR DESCRIPTION
With this implementation, multi-dimensional arrays can be passed
to League\OAuth1\Client\Server::getHeaders() and be correctly
transformed. For prior art, consider the [WP REST API - OAuth 1.0a Server](https://github.com/WP-API/OAuth1)
plugin. Specifically:
* [https://github.com/WP-API/OAuth1/blob/master/lib/class-wp-rest-oauth1.php#L667-L674](https://github.com/WP-API/OAuth1/blob/master/lib/class-wp-rest-oauth1.php#L667-L674)
* [https://github.com/WP-API/OAuth1/blob/master/lib/class-wp-rest-oauth1.php#L706-L753](https://github.com/WP-API/OAuth1/blob/master/lib/class-wp-rest-oauth1.php#L706-L753)