### PR TITLE
Allow mult-dimension arrays when generating base string for HMAC-SHA1 signature. Fixes #39

### DIFF
--- a/src/Client/Signature/HmacSha1Signature.php
+++ b/src/Client/Signature/HmacSha1Signature.php
@@ -62,17 +62,52 @@ class HmacSha1Signature extends Signature implements SignatureInterface
 
         $data = array();
         parse_str($url->getQuery(), $query);
-        foreach (array_merge($query, $parameters) as $key => $value) {
-            $data[rawurlencode($key)] = rawurlencode($value);
-        }
+        $data = array_merge($query, $parameters);
 
-        ksort($data);
-        array_walk($data, function (&$value, $key) {
-            $value = $key.'='.$value;
+        // normalize data key/values
+        array_walk_recursive($data, function (&$key, &$value) {
+            $key   = rawurlencode(rawurldecode($key));
+            $value = rawurlencode(rawurldecode($value));
         });
-        $baseString .= rawurlencode(implode('&', $data));
+        ksort($data);
+
+        $baseString .= $this->queryStringFromData($data);
 
         return $baseString;
+    }
+
+    /**
+     * Creates an array of urlencoded strings out of each array key/value pair
+     * Handles multi-demensional arrays recursively.
+     *
+     * @param  array  $data        Array of parameters to convert.
+     * @param  array  $queryParams Array to extend. False by default.
+     * @param  string $prevKey     Optional Array key to append
+     *
+     * @return string              urlencoded string version of data
+     */
+    protected function queryStringFromData($data, $queryParams = false, $prevKey = '')
+    {
+        if ($initial = (false === $queryParams)) {
+            $queryParams = array();
+        }
+
+        foreach ($data as $key => $value) {
+            if ($prevKey) {
+                $key = $prevKey.'['.$key.']'; // Handle multi-dimensional array
+            }
+            if (is_array($value)) {
+                $queryParams = $this->queryStringFromData($value, $queryParams, $key);
+            } else {
+                $queryParams[] = urlencode($key.'='.$value); // join with equals sign
+            }
+        }
+
+        if ($initial) {
+            return implode('%26', $queryParams); // join with ampersand
+        }
+
+        return $queryParams;
     }
 
     /**

--- a/src/Client/Signature/HmacSha1Signature.php
+++ b/src/Client/Signature/HmacSha1Signature.php
@@ -77,14 +77,14 @@ class HmacSha1Signature extends Signature implements SignatureInterface
     }
 
     /**
-     * Creates an array of urlencoded strings out of each array key/value pair
+     * Creates an array of rawurlencoded strings out of each array key/value pair
      * Handles multi-demensional arrays recursively.
      *
      * @param  array  $data        Array of parameters to convert.
      * @param  array  $queryParams Array to extend. False by default.
      * @param  string $prevKey     Optional Array key to append
      *
-     * @return string              urlencoded string version of data
+     * @return string              rawurlencoded string version of data
      */
     protected function queryStringFromData($data, $queryParams = false, $prevKey = '')
     {
@@ -99,7 +99,7 @@ class HmacSha1Signature extends Signature implements SignatureInterface
             if (is_array($value)) {
                 $queryParams = $this->queryStringFromData($value, $queryParams, $key);
             } else {
-                $queryParams[] = urlencode($key.'='.$value); // join with equals sign
+                $queryParams[] = rawurlencode($key.'='.$value); // join with equals sign
             }
         }
 

--- a/tests/HmacSha1SignatureTest.php
+++ b/tests/HmacSha1SignatureTest.php
@@ -1,4 +1,5 @@
 <?php namespace League\OAuth1\Client\Tests;
+
 /**
  * Part of the Sentry package.
  *
@@ -42,6 +43,116 @@ class HmacSha1SignatureTest extends PHPUnit_Framework_TestCase
         $parameters = array('foo' => 'bar', 'baz' => null);
 
         $this->assertEquals('A3Y7C1SUHXR1EBYIUlT3d6QT1cQ=', $signature->sign($uri, $parameters));
+    }
+
+    public function testQueryStringFromArray()
+    {
+        $array = array('a' => 'b');
+        $res = $this->invokeQueryStringFromData($array);
+
+        $this->assertSame(
+            'a%3Db',
+            $res
+        );
+    }
+
+    public function testQueryStringFromIndexedArray()
+    {
+        $array = array('a', 'b');
+        $res = $this->invokeQueryStringFromData($array);
+
+        $this->assertSame(
+            '0%3Da%261%3Db',
+            $res
+        );
+    }
+
+    public function testQueryStringFromMultiDimensionalArray()
+    {
+        $array = array(
+            'a' => array(
+                'b' => array(
+                    'c' => 'd',
+                ),
+                'e' => array(
+                    'f' => 'g',
+                ),
+            ),
+            'h' => 'i',
+            'empty' => '',
+            'null' => null,
+            'false' => false,
+        );
+
+        // Convert to query string.
+        $res = $this->invokeQueryStringFromData($array);
+
+        $this->assertSame(
+            'a%5Bb%5D%5Bc%5D%3Dd%26a%5Be%5D%5Bf%5D%3Dg%26h%3Di%26empty%3D%26null%3D%26false%3D',
+            $res
+        );
+
+        // Reverse engineer the string.
+        $res = urldecode($res);
+
+        $this->assertSame(
+            'a[b][c]=d&a[e][f]=g&h=i&empty=&null=&false=',
+            $res
+        );
+
+        // Finally, parse the string back to an array.
+        parse_str($res, $original_array);
+
+        // And ensure it matches the orignal array (approximately).
+        $this->assertSame(
+            array(
+                'a' => array(
+                    'b' => array(
+                        'c' => 'd',
+                    ),
+                    'e' => array(
+                        'f' => 'g',
+                    ),
+                ),
+                'h' => 'i',
+                'empty' => '',
+                'null' => '', // null value gets lost in string translation
+                'false' => '', // false value gets lost in string translation
+            ),
+            $original_array
+        );
+    }
+
+    public function testSigningRequestWithMultiDimensionalParams()
+    {
+        $signature = new HmacSha1Signature($this->getMockClientCredentials());
+
+        $uri = 'http://www.example.com/';
+        $parameters = array(
+            'a' => array(
+                'b' => array(
+                    'c' => 'd',
+                ),
+                'e' => array(
+                    'f' => 'g',
+                ),
+            ),
+            'h' => 'i',
+            'empty' => '',
+            'null' => null,
+            'false' => false,
+        );
+
+        $this->assertEquals('ZUxiJKugeEplaZm9e4hshN0I70U=', $signature->sign($uri, $parameters));
+    }
+
+    protected function invokeQueryStringFromData(array $args)
+    {
+        $signature = new HmacSha1Signature(m::mock('League\OAuth1\Client\Credentials\ClientCredentialsInterface'));
+        $refl = new \ReflectionObject($signature);
+        $method = $refl->getMethod('queryStringFromData');
+        $method->setAccessible(true);
+        return $method->invokeArgs($signature, array($args));
     }
 
     protected function getMockClientCredentials()


### PR DESCRIPTION
With this implementation, multi-dimensional arrays can be passed
to League\OAuth1\Client\Server::getHeaders() and be correctly
transformed. For prior art, consider the [WP REST API - OAuth 1.0a Server](https://github.com/WP-API/OAuth1)
plugin. Specifically:
* [https://github.com/WP-API/OAuth1/blob/master/lib/class-wp-rest-oauth1.php#L667-L674](https://github.com/WP-API/OAuth1/blob/master/lib/class-wp-rest-oauth1.php#L667-L674)
* [https://github.com/WP-API/OAuth1/blob/master/lib/class-wp-rest-oauth1.php#L706-L753](https://github.com/WP-API/OAuth1/blob/master/lib/class-wp-rest-oauth1.php#L706-L753)

Includes tests. (closing #60)