### PR TITLE
The package guzzle/guzzle has been superseded by guzzlehttp/guzzle.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "license": "MIT",
     "require": {
         "php": ">=5.3.0",
-        "guzzle/guzzle": "3.*"
+        "guzzlehttp/guzzle": "3.*"
     },
     "require-dev": {
         "phpunit/phpunit": "~4.0",


### PR DESCRIPTION
This update fixes the following Composer issue:

`Package guzzle/guzzle is abandoned, you should avoid using it. Use guzzlehttp/guzzle instead.`