### PR TITLE
Added link to Xero provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ so please help them out with a pull request if you notice this.
 - [Intuit](https://packagist.org/packages/wheniwork/oauth1-intuit)
 - [500px](https://packagist.org/packages/mechant/oauth1-500px)
 - [Etsy](https://packagist.org/packages/y0lk/oauth1-etsy)
+- [Xero](https://packagist.org/packages/Invoiced/oauth1-xero)
 
 #### Terminology (as per the RFC 5849 specification):
 


### PR DESCRIPTION
This is a fantastic package! We wanted to share the [Xero](https://xero.com) provider we wrote. :)