### PR TITLE
Updated dependency in composer.json to use guzzlehttp/guzzle instead of guzzle/guzzle

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "license": "MIT",
     "require": {
         "php": ">=5.3.0",
-        "guzzle/guzzle": "3.*"
+        "guzzlehttp/guzzle": "3.*"
     },
     "require-dev": {
         "phpunit/phpunit": "~4.0",


### PR DESCRIPTION
```laravel/socialite``` and others depending on this package display

> **Package guzzle/guzzle is abandoned, you should avoid using it. Use guzzlehttp/guzzle instead.**

so I've update the guzzle dependency.

Tests seem to run just fine

```
gabriel@~:oauth1-client (git:master) $ phpunit
PHPUnit 4.8.26 by Sebastian Bergmann and contributors.
Warning:	The Xdebug extension is not loaded
		No code coverage will be generated.

.....................................

Time: 212 ms, Memory: 8.75MB

OK (37 tests, 114 assertions)
```