### PR TITLE
Update Guzzle to the latest version 6.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "license": "MIT",
     "require": {
         "php": ">=5.3.0",
-        "guzzle/guzzle": "3.*"
+        "guzzlehttp/guzzle": "6.*"
     },
     "require-dev": {
         "phpunit/phpunit": "~4.0",

--- a/src/Client/Server/Server.php
+++ b/src/Client/Server/Server.php
@@ -2,8 +2,8 @@
 
 namespace League\OAuth1\Client\Server;
 
-use Guzzle\Service\Client as GuzzleClient;
-use Guzzle\Http\Exception\BadResponseException;
+use GuzzleHttp\Client as GuzzleClient;
+use GuzzleHttp\Exception\BadResponseException;
 use League\OAuth1\Client\Credentials\ClientCredentialsInterface;
 use League\OAuth1\Client\Credentials\ClientCredentials;
 use League\OAuth1\Client\Credentials\CredentialsInterface;

--- a/src/Client/Signature/HmacSha1Signature.php
+++ b/src/Client/Signature/HmacSha1Signature.php
@@ -19,23 +19,9 @@ class HmacSha1Signature extends Signature implements SignatureInterface
      */
     public function sign($uri, array $parameters = array(), $method = 'POST')
     {
-        $url = $this->createUrl($uri);
-
-        $baseString = $this->baseString($url, $method, $parameters);
+        $baseString = $this->baseString($uri, $method, $parameters);
 
         return base64_encode($this->hash($baseString));
-    }
-
-    /**
-     * Create a Guzzle url for the given URI.
-     *
-     * @param string $uri
-     *
-     * @return Url
-     */
-    protected function createUrl($uri)
-    {
-        return Url::factory($uri);
     }
 
     /**
@@ -48,21 +34,22 @@ class HmacSha1Signature extends Signature implements SignatureInterface
      *
      * @return string
      */
-    protected function baseString(Url $url, $method = 'POST', array $parameters = array())
+    protected function baseString($uri, $method = 'POST', array $parameters = array())
     {
         $baseString = rawurlencode($method).'&';
 
-        $schemeHostPath = Url::buildUrl(array(
-           'scheme' => $url->getScheme(),
-           'host' => $url->getHost(),
-           'path' => $url->getPath(),
-        ));
+        $url = parse_url($uri);
+
+        $schemeHostPath = "{$url['scheme']}://{$url['host']}{$url['path']}";
 
         $baseString .= rawurlencode($schemeHostPath).'&';
 
-        $data = array();
-        parse_str($url->getQuery(), $query);
+        $query = array();
+        if (isset($url['query'])) {
+            parse_str($url['query'], $query);
+        }
         $data = array_merge($query, $parameters);
+
 
         // normalize data key/values
         array_walk_recursive($data, function (&$key, &$value) {


### PR DESCRIPTION
It removes the dependency on the old deprecated Guzzle 3.x and uses 6.x instead (with the new vendor and namespace).

It fixes #72 