### PR TITLE
Move to supported guzzlehttp

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "license": "MIT",
     "require": {
         "php": ">=5.3.0",
-        "guzzle/guzzle": "3.*"
+        "guzzlehttp/guzzle": "3.*"
     },
     "require-dev": {
         "phpunit/phpunit": "~4.0",


### PR DESCRIPTION
guzzle/guzzle is abandoned and composer complains about it. guzzlehttp is a drop in replacement (no need to change code).

phpunit completes successfully with this change and composer happier.