### PR TITLE
Including non-standard ports into a base string

### DIFF
--- a/src/Client/Signature/HmacSha1Signature.php
+++ b/src/Client/Signature/HmacSha1Signature.php
@@ -40,6 +40,29 @@ class HmacSha1Signature extends Signature implements SignatureInterface
     }
 
     /**
+     * Creates a host string according to https://oauth.net/core/1.0a/#rfc.section.9.1.2
+     *
+     * @param Uri $url
+     *
+     * @return string
+     */
+    protected function prepareHostString(Uri $url)
+    {
+        $urlParts = array(
+            'scheme' => $url->getScheme(),
+            'host' => $url->getHost(),
+            'path' => $url->getPath(),
+        );
+
+        $port = $url->getPort();
+        if ($port && $port !== 80 && $port !== 443) {
+            $urlParts['port'] = $port;
+        }
+
+        return Uri::fromParts($urlParts);
+    }
+
+    /**
      * Generate a base string for a HMAC-SHA1 signature
      * based on the given a url, method, and any parameters.
      *
@@ -53,13 +76,9 @@ class HmacSha1Signature extends Signature implements SignatureInterface
     {
         $baseString = rawurlencode($method).'&';
 
-        $schemeHostPath = Uri::fromParts(array(
-           'scheme' => $url->getScheme(),
-           'host' => $url->getHost(),
-           'path' => $url->getPath(),
-        ));
+        $hostString = $this->prepareHostString($url);
 
-        $baseString .= rawurlencode($schemeHostPath).'&';
+        $baseString .= rawurlencode($hostString).'&';
 
         $data = array();
         parse_str($url->getQuery(), $query);

--- a/tests/HmacSha1SignatureTest.php
+++ b/tests/HmacSha1SignatureTest.php
@@ -45,6 +45,36 @@ class HmacSha1SignatureTest extends PHPUnit_Framework_TestCase
         $this->assertEquals('A3Y7C1SUHXR1EBYIUlT3d6QT1cQ=', $signature->sign($uri, $parameters));
     }
 
+    public function testSigningRequestWith80thPort()
+    {
+        $signature = new HmacSha1Signature($this->getMockClientCredentials());
+
+        $uri = 'http://www.example.com:80/?qux=corge';
+        $parameters = array('foo' => 'bar', 'baz' => null);
+
+        $this->assertEquals('A3Y7C1SUHXR1EBYIUlT3d6QT1cQ=', $signature->sign($uri, $parameters));
+    }
+
+    public function testSigningRequestWith443thPort()
+    {
+        $signature = new HmacSha1Signature($this->getMockClientCredentials());
+
+        $uri = 'https://www.example.com:443/?qux=corge';
+        $parameters = array('foo' => 'bar', 'baz' => null);
+
+        $this->assertEquals('sNS9G4Ft7wRj+F8nygSEiokgvog=', $signature->sign($uri, $parameters));
+    }
+
+    public function testSigningRequestWithNonStandardPort()
+    {
+        $signature = new HmacSha1Signature($this->getMockClientCredentials());
+
+        $uri = 'https://www.example.com:8080/?qux=corge';
+        $parameters = array('foo' => 'bar', 'baz' => null);
+
+        $this->assertEquals('ccm9Tkv8PCxH6OjLJqwlCWBENro=', $signature->sign($uri, $parameters));
+    }
+
     public function testQueryStringFromArray()
     {
         $array = array('a' => 'b');


### PR DESCRIPTION
This PR fixes building a signature basic string according to this section https://oauth.net/core/1.0a/#rfc.section.9.1.2 