### PR TITLE
add accept header to default headers

### DIFF
--- a/src/Client/Server/Server.php
+++ b/src/Client/Server/Server.php
@@ -358,6 +358,7 @@ abstract class Server
         if (!empty($this->userAgent)) {
             $defaultHeaders['User-Agent'] = $this->userAgent;
         }
+        $defaultHeaders['Accept'] = 'application/'. $this->responseType;
 
         return $defaultHeaders;
     }


### PR DESCRIPTION
Explicitly require the correct response type from the server, rather than assuming it will match the named type. Closes #85 