### PR TITLE
Switch Twitter urlAuthorization to 'authorize'

### DIFF
--- a/src/Client/Server/Twitter.php
+++ b/src/Client/Server/Twitter.php
@@ -19,7 +19,7 @@ class Twitter extends Server
      */
     public function urlAuthorization()
     {
-        return 'https://api.twitter.com/oauth/authenticate';
+        return 'https://api.twitter.com/oauth/authorize';
     }
 
     /**


### PR DESCRIPTION
When working with [Socialite](https://github.com/laravel/socialite) I noticed the callback URL for Twitter was wrong, at least for me. This PR aims to fix that.

I read your contributing guide but failed to find any existing tests to test Twitter. I'd be more than happy to work with you to make this a useful contribution and I thank you for your time and effort.