### PR TITLE
Add checks for token and secret to Server->createTokenCredentials()

### DIFF
--- a/src/Client/Server/Server.php
+++ b/src/Client/Server/Server.php
@@ -496,6 +496,14 @@ abstract class Server
             throw new CredentialsException("Error [{$data['error']}] in retrieving token credentials.");
         }
 
+        if (!isset($data['oauth_token'])) {
+            throw new CredentialsException('No token found.');
+        }
+
+        if (!isset($data['oauth_token_secret'])) {
+            throw new CredentialsException('No token secret found.');
+        }
+
         $tokenCredentials = new TokenCredentials();
         $tokenCredentials->setIdentifier($data['oauth_token']);
         $tokenCredentials->setSecret($data['oauth_token_secret']);


### PR DESCRIPTION
If a server (e.g. [Xero](https://xero.com)) does not return a token for any reason (see [its documentation](https://developer.xero.com/documentation/auth-and-limits/oauth-issues)), `Server` currently generates a notice because the data is assumed to be present in `createTokenCredentials()` and isn't in such cases.

```
Notice: Undefined index: oauth_token
 () at /src/vendor/league/oauth1-client/src/Client/Server/Server.php:487
 League\OAuth1\Client\Server\Server->createTokenCredentials()
```

This PR adds checks and throws appropriate instances of `CredentialsException` if either the token or the secret is missing.