### PR TITLE
Relax from PHP 7.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,12 @@ language: php
 
 matrix:
   include:
+    - php: 7.1
+      dist: bionic
+      env: COMPOSER_OPTS=""
+    - php: 7.1
+      dist: bionic
+      env: COMPOSER_OPTS="--prefer-lowest"
     - php: 7.2
       dist: bionic
       env: COMPOSER_OPTS=""

--- a/composer.json
+++ b/composer.json
@@ -3,13 +3,13 @@
     "description": "OAuth 1.0 Client Library",
     "license": "MIT",
     "require": {
-        "php": ">=7.2",
+        "php": ">=7.1",
         "ext-json": "*",
         "ext-openssl": "*",
         "guzzlehttp/guzzle": "^6.0|^7.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^8.5",
+        "phpunit/phpunit": "^7.5",
         "mockery/mockery": "^1.3",
         "squizlabs/php_codesniffer": "^2.9"
     },


### PR DESCRIPTION
There was really nothing from PHP 7.2 that we specifically required over PHP 7.1, except that PHP 7.1 has reached EOL.

A major consumer of this package, [Laravel Socialite](https://github.com/laravel/socialite) only requires PHP 7.1+, so by restricting a new version to PHP 7.2, we'd be potentially blocking their users from receiving updates.