### PR TITLE
chore: added .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,14 @@
+/.gitattributes export-ignore
+/.gitignore export-ignore
+/.php_cs.dist export-ignore
+/.scrutinizer.yml export-ignore
+/.travis.yml export-ignore
+/CHANGELOG.md export-ignore
+/composer.json export-ignore
+/CONDUCT.md export-ignore
+/CONTRIBUTING.md export-ignore
+/phpstan.neon export-ignore
+/phpunit.xml export-ignore
+/README.md export-ignore
+/rfc5849.txt export-ignore
+/tests export-ignore


### PR DESCRIPTION
Exclude these files from the composer package. Offers better `vendor` security and smaller downloads.

See https://php.watch/articles/composer-gitattributes#export-ignore