### PR TITLE
Optional authorization parameters

### DIFF
--- a/src/Server/Server.php
+++ b/src/Server/Server.php
@@ -113,10 +113,11 @@ abstract class Server
      * identifier or an object instance.
      *
      * @param TemporaryCredentials|string $temporaryIdentifier
+     * @param array                       $options
      *
      * @return string
      */
-    public function getAuthorizationUrl($temporaryIdentifier)
+    public function getAuthorizationUrl($temporaryIdentifier, array $options = [])
     {
         // Somebody can pass through an instance of temporary
         // credentials and we'll extract the identifier from there.
@@ -124,7 +125,7 @@ abstract class Server
             $temporaryIdentifier = $temporaryIdentifier->getIdentifier();
         }
 
-        $parameters = ['oauth_token' => $temporaryIdentifier];
+        $parameters = array_merge($options, ['oauth_token' => $temporaryIdentifier]);
 
         $url = $this->urlAuthorization();
         $queryString = http_build_query($parameters);

--- a/tests/ServerTest.php
+++ b/tests/ServerTest.php
@@ -123,6 +123,16 @@ class ServerTest extends TestCase
         $this->assertEquals($expected, $server->getAuthorizationUrl($credentials));
     }
 
+    public function testGettingAuthorizationUrlWithOptions()
+    {
+        $server = new ServerStub($this->getMockClientCredentials());
+        $expected = 'http://www.example.com/authorize?oauth_token=foo';
+        $this->assertEquals($expected, $server->getAuthorizationUrl('foo', ['oauth_token' => 'bar']));
+
+        $expected = 'http://www.example.com/authorize?test=bar&oauth_token=foo';
+        $this->assertEquals($expected, $server->getAuthorizationUrl('foo', ['test' => 'bar']));
+    }
+
     public function testGettingTokenCredentialsFailsWithManInTheMiddle()
     {
         $server = new ServerStub($this->getMockClientCredentials());


### PR DESCRIPTION
Optional authorization URL creation parameter in vain of Oauth2 to be appended to the URL. No change in case you don't use it, if you do, you can add parameters to the authorization URL. 

Resolves #130 