### PR TITLE
Remove deprecated Guzzle function call

### DIFF
--- a/src/Signature/EncodesUrl.php
+++ b/src/Signature/EncodesUrl.php
@@ -4,6 +4,7 @@ namespace League\OAuth1\Client\Signature;
 
 use GuzzleHttp\Psr7;
 use GuzzleHttp\Psr7\Uri;
+use function GuzzleHttp\Psr7\uri_for;
 use Psr\Http\Message\UriInterface;
 
 trait EncodesUrl
@@ -17,6 +18,11 @@ trait EncodesUrl
      */
     protected function createUrl($uri)
     {
+        if (method_exists(Psr7\Utils::class, 'uriFor')) {
+            return Psr7\Utils::uriFor($uri);
+        }
+
+        // Deprecated, removed in Guzzle 7.2
         return Psr7\uri_for($uri);
     }
 


### PR DESCRIPTION
The `GuzzleHttp\Psr7\uri_for` function is deprecated and removed in Guzzle 7.2.  Where available `GuzzleHttp\Psr7\Utils::uriFor` is used instead.

Given we support Guzzle 6 and 7, both the method and function call are required to be supported.

Fixes #134.