### PR TITLE
Add 'x_auth_access_type' parameter for Twitter to change the access level of an application

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,7 @@ $server = new League\OAuth1\Client\Server\Twitter([
     'identifier' => 'your-identifier',
     'secret' => 'your-secret',
     'callback_uri' => "http://your-callback-uri/",
+    'scope' => 'your-application-scope' // optional ('read', 'write'), defaults to 'read'
 ]);
 ```
 

--- a/src/Server/Server.php
+++ b/src/Server/Server.php
@@ -553,6 +553,17 @@ abstract class Server
     }
 
     /**
+     * Any additional required protocol parameters for an
+     * OAuth request to get temporary credentials.
+     *
+     * @return array
+     */
+    protected function additionalTemporaryCredentialsProtocolParameters()
+    {
+        return [];
+    }
+
+    /**
      * Generate the OAuth protocol header for a temporary credentials
      * request, based on the URI.
      *
@@ -562,9 +573,13 @@ abstract class Server
      */
     protected function temporaryCredentialsProtocolHeader($uri)
     {
-        $parameters = array_merge($this->baseProtocolParameters(), [
-            'oauth_callback' => $this->clientCredentials->getCallbackUri(),
-        ]);
+        $parameters = array_merge(
+            $this->baseProtocolParameters(),
+            $this->additionalTemporaryCredentialsProtocolParameters(),
+            [
+                'oauth_callback' => $this->clientCredentials->getCallbackUri(),
+            ]
+        );
 
         $parameters['oauth_signature'] = $this->signature->sign($uri, $parameters, 'POST');
 

--- a/src/Server/Twitter.php
+++ b/src/Server/Twitter.php
@@ -3,9 +3,53 @@
 namespace League\OAuth1\Client\Server;
 
 use League\OAuth1\Client\Credentials\TokenCredentials;
+use League\OAuth1\Client\Signature\SignatureInterface;
 
 class Twitter extends Server
 {
+    /**
+     * Application scope.
+     *
+     * @var string
+     */
+    protected $applicationScope;
+
+    /**
+     * @inheritDoc
+     */
+    public function __construct($clientCredentials, SignatureInterface $signature = null)
+    {
+        parent::__construct($clientCredentials, $signature);
+
+        if (is_array($clientCredentials)) {
+            $this->parseConfiguration($clientCredentials);
+        }
+    }
+
+    /**
+     * Set the application scope.
+     *
+     * @param string $applicationScope
+     *
+     * @return Twitter
+     */
+    public function setApplicationScope($applicationScope)
+    {
+        $this->applicationScope = $applicationScope;
+
+        return $this;
+    }
+
+    /**
+     * Get application scope.
+     *
+     * @return string
+     */
+    public function getApplicationScope()
+    {
+        return $this->applicationScope ?: 'read';
+    }
+
     /**
      * @inheritDoc
      */
@@ -96,5 +140,35 @@ class Twitter extends Server
     public function userScreenName($data, TokenCredentials $tokenCredentials)
     {
         return $data['name'];
+    }
+
+    /**
+     * @inheritDoc
+     */
+    protected function additionalTemporaryCredentialsProtocolParameters()
+    {
+        return [
+            'x_auth_access_type' => $this->getApplicationScope()
+        ];
+    }
+
+    /**
+     * Parse configuration array to set attributes.
+     *
+     * @param array $configuration
+     *
+     * @return void
+     */
+    private function parseConfiguration(array $configuration = [])
+    {
+        $configToPropertyMap = [
+            'scope' => 'applicationScope',
+        ];
+
+        foreach ($configToPropertyMap as $config => $property) {
+            if (isset($configuration[$config])) {
+                $this->$property = $configuration[$config];
+            }
+        }
     }
 }


### PR DESCRIPTION
Hey,

I use Socialite on my app and I notice that the 'x_auth_access_type' parameter for Twitter was not handle in your package.
This parameter can be used to define the access level of the application. Here is the documentation about the [Twitter request_token endpoint](https://developer.twitter.com/en/docs/authentication/api-reference/request_token).
I'll need to open a pull request on Socialite as well to handle this modification.

I'm open if you have a better implementation for this that can be handle by Socialite natively.