### PR TITLE
Fixes #139: fix error about twitter scope when getting temporary credentials

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ $server = new League\OAuth1\Client\Server\Twitter([
     'identifier' => 'your-identifier',
     'secret' => 'your-secret',
     'callback_uri' => "http://your-callback-uri/",
-    'scope' => 'your-application-scope' // optional ('read', 'write'), defaults to 'read'
+    'scope' => 'your-application-scope' // optional ('read', 'write'), empty by default
 ]);
 ```
 

--- a/src/Server/Server.php
+++ b/src/Server/Server.php
@@ -553,17 +553,6 @@ abstract class Server
     }
 
     /**
-     * Any additional required protocol parameters for an
-     * OAuth request to get temporary credentials.
-     *
-     * @return array
-     */
-    protected function additionalTemporaryCredentialsProtocolParameters()
-    {
-        return [];
-    }
-
-    /**
      * Generate the OAuth protocol header for a temporary credentials
      * request, based on the URI.
      *
@@ -575,7 +564,6 @@ abstract class Server
     {
         $parameters = array_merge(
             $this->baseProtocolParameters(),
-            $this->additionalTemporaryCredentialsProtocolParameters(),
             [
                 'oauth_callback' => $this->clientCredentials->getCallbackUri(),
             ]

--- a/src/Server/Twitter.php
+++ b/src/Server/Twitter.php
@@ -10,9 +10,9 @@ class Twitter extends Server
     /**
      * Application scope.
      *
-     * @var string
+     * @var ?string
      */
-    protected $applicationScope;
+    protected $applicationScope = null;
 
     /**
      * @inheritDoc
@@ -29,7 +29,7 @@ class Twitter extends Server
     /**
      * Set the application scope.
      *
-     * @param string $applicationScope
+     * @param ?string $applicationScope
      *
      * @return Twitter
      */
@@ -43,11 +43,11 @@ class Twitter extends Server
     /**
      * Get application scope.
      *
-     * @return string
+     * @return ?string
      */
     public function getApplicationScope()
     {
-        return $this->applicationScope ?: 'read';
+        return $this->applicationScope;
     }
 
     /**
@@ -55,7 +55,10 @@ class Twitter extends Server
      */
     public function urlTemporaryCredentials()
     {
-        return 'https://api.twitter.com/oauth/request_token';
+        $url = 'https://api.twitter.com/oauth/request_token';
+        $queryParams = $this->temporaryCredentialsQueryParameters();
+
+        return empty($queryParams) ? $url : $url . '?' . $queryParams;
     }
 
     /**
@@ -143,13 +146,19 @@ class Twitter extends Server
     }
 
     /**
-     * @inheritDoc
+     * Query parameters for a Twitter OAuth request to get temporary credentials.
+     *
+     * @return string
      */
-    protected function additionalTemporaryCredentialsProtocolParameters()
+    protected function temporaryCredentialsQueryParameters()
     {
-        return [
-            'x_auth_access_type' => $this->getApplicationScope()
-        ];
+        $queryParams = [];
+
+        if ($scope = $this->getApplicationScope()) {
+            $queryParams['x_auth_access_type'] = $scope;
+        }
+
+        return http_build_query($queryParams);
     }
 
     /**


### PR DESCRIPTION
Hey,
Here is a fix about [my last pull request](https://github.com/thephpleague/oauth1-client/pull/138) that added support for the Twitter `x_auth_access_type` parameter.
I thought that the API need it in the Authorization header, but after a lot of research, I found that this parameter needs to be specified in the query string. Also, it needs to be present when the URL is signed for the oauth request.

This time I test my work and all is good.
Sorry again.