### PR TITLE
Fix Twitter OAuth1.0a Request Token Error

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 /.phpunit.result.cache
 /.php_cs.cache
 .DS_Store
+pr

--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,3 @@
 /.phpunit.result.cache
 /.php_cs.cache
 .DS_Store
-pr

--- a/src/Server/Twitter.php
+++ b/src/Server/Twitter.php
@@ -54,7 +54,7 @@ class Twitter extends Server
      */
     public function urlTemporaryCredentials()
     {
-        $url = 'https://api.twitter.com/oauth/request_token';
+        $url = 'https://api.x.com/oauth/request_token';
         $queryParams = $this->temporaryCredentialsQueryParameters();
 
         return empty($queryParams) ? $url : $url . '?' . $queryParams;
@@ -65,7 +65,7 @@ class Twitter extends Server
      */
     public function urlAuthorization()
     {
-        return 'https://api.twitter.com/oauth/authenticate';
+        return 'https://api.x.com/oauth/authenticate';
     }
 
     /**
@@ -73,7 +73,7 @@ class Twitter extends Server
      */
     public function urlTokenCredentials()
     {
-        return 'https://api.twitter.com/oauth/access_token';
+        return 'https://api.x.com/oauth/access_token';
     }
 
     /**
@@ -81,7 +81,7 @@ class Twitter extends Server
      */
     public function urlUserDetails()
     {
-        return 'https://api.twitter.com/1.1/account/verify_credentials.json?include_email=true';
+        return 'https://api.x.com/1.1/account/verify_credentials.json?include_email=true';
     }
 
     /**
@@ -106,7 +106,7 @@ class Twitter extends Server
 
         foreach ($data as $key => $value) {
             if (strpos($key, 'url') !== false) {
-                if ( ! in_array($key, $used)) {
+                if (! in_array($key, $used)) {
                     $used[] = $key;
                 }
 


### PR DESCRIPTION
# Pull Request: Fix Twitter OAuth1a Request Token Issue

This is an explaination for the pull request used in a [Laravel](https://laravel.com/docs/11.x) & [Socialite](https://laravel.com/docs/11.x/socialite) Application

## Motivation

Twitter OAuth2 always returns a null email, unlike OAuth1 which does not, in addition to providing the developers with much more data than OAuth2

## Scenario To Reproduce

1. Create an appliction on [X Developer Portal](https://developer.x.com/en/portal/dashboard)
2. On the left of the dashboard, choose `Projects & Apps > Default Project-xxxxxxxxx > <YOUR_APP>`
3. Go to `Keys & Tokens`
4. Regenerate the `Consumer Keys` as shown, these will be OAuth1 Credentials

![image](https://github.com/user-attachments/assets/989893e1-1a19-47c2-821b-6274a981ccce)

5. Store the credentials in your application `.env` file

```bash
TWITTER_CLIENT_ID="<YOUR_CLIENT_ID>"
TWITTER_CLIENT_SECRET="<YOUR_CLIENT_SECRET>"
TWITTER_REDIRECT_URL="https://yourapp.loophole.site/login/oauth/twitter" # I am using a SSH Tunneling service to provide a secure endpoints, there are many available like ngrok and loophole and localtunnel
```
6. Add your socialite configuration in `config/services.php`

```php
'twitter' => [
    'client_id' => env('TWITTER_CLIENT_ID'),
    'client_secret' => env('TWITTER_CLIENT_SECRET'),
    'redirect' => env('TWITTER_REDIRECT_URL')
]
```

7. use socialite as usual in your controller (issue appears here)

```php
class SocialAuthController extends Controller
{
    public function oauthRedirect(string $oauth)
    {
        switch ($oauth) {
            case "google":
            case "facebook":
            case "twitter":
                return Socialite::driver($oauth)->redirect();
                // return Inertia::location(Socialite::driver($oauth)->redirect()); // if you use inertia
                break;
            default:
                return redirect()->route('login');
        }
    }
}
```

8. Result

![image](https://github.com/user-attachments/assets/59be480b-cc53-4d29-a01e-ef1b182d0eee)

## Fix

1. Go to `./vendor/league/oauth1-client/src/Server/Twitter.php`

2. Change `urlAuthorization()` function from

```php
public function urlAuthorization()
{
    return 'https://api.twitter.com/oauth/authenticate';
}
```

to

```php
public function urlAuthorization()
{
    return 'https://api.x.com/oauth/authenticate';
}
```

and the issue will be solved